### PR TITLE
fix: Agent session not storing historical message (#5)

### DIFF
--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -531,6 +531,14 @@ const AgentInterface = () => {
                 return updated;
             });
 
+            if (botText.trim()) {
+                fetch(`/chat_session/${activeSessionId}/history`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ user_content: text, ai_content: botText })
+                }).catch(e => console.error('Failed to save agent history:', e));
+            }
+
         } catch (err) {
             if (err.name === 'AbortError') {
                 setSessions(prev => {

--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -265,13 +265,12 @@ const AgentInterface = () => {
                 const response = await fetch(`/chat_session/${activeSessionId}/history`);
                 if (!response.ok) throw new Error('Failed to fetch history');
                 const data = await response.json();
+                const items = Array.isArray(data) ? data : (data.messages || []);
+                const sorted = [...items].sort((a, b) => (a.message_order || 0) - (b.message_order || 0));
 
-                setSessions(prev => prev.map(s => {
-                    if (s.id === activeSessionId) {
-                        return { ...s, messages: data.messages || [] };
-                    }
-                    return s;
-                }));
+                setSessions(prev => prev.map(s =>
+                    s.id === activeSessionId ? { ...s, messages: sorted } : s
+                ));
             } catch (error) {
                 console.error("Error fetching run history:", error);
             }


### PR DESCRIPTION
## Summary
- `AgentInterface` was updating messages only in React state — no API call was made to persist them to the DB
- Added a fire-and-forget `POST /chat_session/{id}/history` call after the stream finalizes, matching the pattern already used in `ChatInterface`
- Guarded with `botText.trim()` to skip saving empty responses (e.g. pure tool-call turns with no text)

## Related Issue
Closes #5

## Test plan
- [ ] Send a message in an Agent session, then refresh the page — history should reappear
- [ ] Verify a pure tool-call response (no text) does not create a blank history entry
- [ ] Verify stopping a stream mid-way does not persist an incomplete message

🤖 Generated with [Claude Code](https://claude.com/claude-code)