### PR TITLE
fix: Agent session history no used tools information (#7)

### DIFF
--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -266,7 +266,14 @@ const AgentInterface = () => {
                 if (!response.ok) throw new Error('Failed to fetch history');
                 const data = await response.json();
                 const items = Array.isArray(data) ? data : (data.messages || []);
-                const sorted = [...items].sort((a, b) => (a.message_order || 0) - (b.message_order || 0));
+                const sorted = [...items]
+                    .sort((a, b) => (a.message_order || 0) - (b.message_order || 0))
+                    .map(({ used_tools, ...item }) => ({
+                        ...item,
+                        toolCalls: item.role === 'assistant'
+                            ? (used_tools || []).map(name => ({ name, args: null, result: null }))
+                            : [],
+                    }));
 
                 setSessions(prev => prev.map(s =>
                     s.id === activeSessionId ? { ...s, messages: sorted } : s


### PR DESCRIPTION
## Summary
- When loading history from `GET /chat_session/{id}/history`, the API now returns `used_tools: ["tool_name"]` on assistant messages
- `loadHistory` previously passed raw API items directly as messages, so `toolCalls` was never set — tool badges were invisible after page refresh
- Now maps `used_tools` → `toolCalls: [{name, args: null, result: null}]` during history loading, only for `assistant` role messages
- Destructures `used_tools` out of the spread to avoid storing redundant data in React state

## Related Issue
Closes #7

## Test plan
- [ ] Send a message in an Agent session that triggers a tool call, then refresh the page — the tool badge should still appear on the assistant message
- [ ] Verify user messages do not show any tool badges
- [ ] Verify assistant messages with no tool usage show no tool badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)