### PR TITLE
fix: Agent session shows Invalid Date in chat history (#8)

### DIFF
--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -268,8 +268,9 @@ const AgentInterface = () => {
                 const items = Array.isArray(data) ? data : (data.messages || []);
                 const sorted = [...items]
                     .sort((a, b) => (a.message_order || 0) - (b.message_order || 0))
-                    .map(({ used_tools, ...item }) => ({
+                    .map(({ used_tools, created_at, ...item }) => ({
                         ...item,
+                        timestamp: created_at || new Date().toISOString(),
                         toolCalls: item.role === 'assistant'
                             ? (used_tools || []).map(name => ({ name, args: null, result: null }))
                             : [],


### PR DESCRIPTION
## Summary
- History messages from `GET /chat_session/{id}/history` have a `created_at` field, but the component's render logic reads `msg.timestamp`
- Since `loadHistory` spread raw API items directly, `msg.timestamp` was `undefined` → `new Date(undefined)` → `Invalid Date`
- Fixed by destructuring `created_at` out of the spread and mapping it to `timestamp: created_at || new Date().toISOString()`, consistent with the fallback pattern used elsewhere in the same component (lines 241, 333)

## Related Issue
Closes #8

## Test plan
- [ ] Load an Agent session with existing history — date separators and message timestamps should display correctly
- [ ] Verify no "Invalid Date" appears in any message bubble or date separator after page refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)