### PR TITLE
fix: tool store 應區分 owner (#11)

### DIFF
--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -200,8 +200,8 @@ const AgentInterface = () => {
             setLoadingTools(true);
             const username = localStorage.getItem('username') || '';
             const [sysRes, ownerRes] = await Promise.all([
-                fetch('/agent/tools'),
-                username ? fetch(`/agent/tools?owner=${username}`) : Promise.resolve(null),
+                fetch('/agent/tools?owner=system'),
+                (username && username !== 'system') ? fetch(`/agent/tools?owner=${username}`) : Promise.resolve(null),
             ]);
 
             if (!sysRes.ok) throw new Error('Failed to fetch system tools');
@@ -210,7 +210,6 @@ const AgentInterface = () => {
 
             if (ownerRes && ownerRes.ok) {
                 const ownerData = await ownerRes.json();
-                // Exclude any that are already system-owned (owner === 'system')
                 const ownerList = Array.isArray(ownerData) ? ownerData : (ownerData.tools || []);
                 setOwnerTools(ownerList.filter(t => t.owner !== 'system'));
             } else {


### PR DESCRIPTION
## Summary
- Changed system tools fetch from `/agent/tools` (no filter) to `/agent/tools?owner=system` so the API explicitly returns only system-owned tools
- User tools were already fetched with `/agent/tools?owner={username}` — no change needed there
- Added guard `username !== 'system'` to prevent accidentally issuing a duplicate system-tools request if a user's login name is `"system"`
- Removed now-redundant inline comment explaining client-side system-tool exclusion

## Related Issue
Closes #11

## Test plan
- [ ] Verify the Tools panel shows system tools (emerald theme) fetched via `?owner=system`
- [ ] Verify user-owned tools (purple theme) are fetched via `?owner={username}`
- [ ] Confirm no duplicate tool entries appear in either section when logged in as a normal user
- [ ] Confirm behavior is correct when no username is stored in localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)