### PR TITLE
feat: Create Tool feature + Tool Store panel controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,5 @@ dist
 
 # Vite
 dist
+
+.claude

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Sidebar from './components/Sidebar';
 import ChatInterface from './components/ChatInterface';
 import AgentInterface from './components/AgentInterface';
+import RagInterface from './components/RagInterface';
 import Dashboard from './components/Dashboard';
 import ComingSoon from './components/ComingSoon';
 import Login from './components/Login';
@@ -63,6 +64,21 @@ function App() {
                                 <RequireAuth>
                                     <PageWrapper>
                                         <AgentInterface />
+                                    </PageWrapper>
+                                </RequireAuth>
+                            } />
+
+                            <Route path="/rag" element={
+                                <RequireAuth>
+                                    <PageWrapper>
+                                        <RagInterface />
+                                    </PageWrapper>
+                                </RequireAuth>
+                            } />
+                            <Route path="/rag/:session_id" element={
+                                <RequireAuth>
+                                    <PageWrapper>
+                                        <RagInterface />
                                     </PageWrapper>
                                 </RequireAuth>
                             } />

--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -120,6 +120,13 @@ const AgentInterface = () => {
     const [isClearModalOpen, setIsClearModalOpen] = useState(false);
     const [sessionToClear, setSessionToClear] = useState(null);
 
+    // Create Tool modal
+    const [isCreateToolModalOpen, setIsCreateToolModalOpen] = useState(false);
+    const [newToolName, setNewToolName] = useState('');
+    const [newToolDesc, setNewToolDesc] = useState('');
+    const [newToolWebhookUrl, setNewToolWebhookUrl] = useState('');
+    const [isCreatingTool, setIsCreatingTool] = useState(false);
+
     // Header menu
     const [isHeaderMenuOpen, setIsHeaderMenuOpen] = useState(false);
     const [menuPos, setMenuPos] = useState({ top: 0, right: 0 });
@@ -354,6 +361,37 @@ const AgentInterface = () => {
 
         setIsClearModalOpen(false);
         setSessionToClear(null);
+    };
+
+    const handleCreateTool = async () => {
+        const name = newToolName.trim();
+        const webhookUrl = newToolWebhookUrl.trim();
+        if (!name || !webhookUrl) return;
+
+        const username = localStorage.getItem('username') || '';
+        setIsCreatingTool(true);
+        try {
+            const response = await fetch('/agent/tools', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name,
+                    owner: username,
+                    description: newToolDesc.trim(),
+                    metadata: { webhook_url: webhookUrl },
+                }),
+            });
+            if (!response.ok) throw new Error('Failed to create tool');
+            setIsCreateToolModalOpen(false);
+            setNewToolName('');
+            setNewToolDesc('');
+            setNewToolWebhookUrl('');
+            fetchTools();
+        } catch (err) {
+            console.error('Error creating tool:', err);
+        } finally {
+            setIsCreatingTool(false);
+        }
     };
 
     const handleSelectSession = (id) => {
@@ -673,21 +711,15 @@ const AgentInterface = () => {
                     </div>
 
                     <div className="flex items-center gap-2">
-                        {/* Tools Panel Toggle */}
-                        {!isMobile && (
+                        {!isMobile && !showToolsPanel && (
                             <button
-                                onClick={() => setShowToolsPanel(v => !v)}
-                                className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-all ${showToolsPanel
-                                    ? 'bg-emerald-500/10 text-emerald-400 border border-emerald-500/20'
-                                    : 'bg-slate-800 text-slate-400 hover:text-slate-200 border border-slate-700/50'
-                                    }`}
-                                title="Toggle tools panel"
+                                onClick={() => setShowToolsPanel(true)}
+                                className="p-1.5 rounded-lg text-slate-500 hover:text-emerald-400 hover:bg-slate-800 transition-colors"
+                                title="Open tool store"
                             >
-                                <Wrench size={13} />
-                                Tools
+                                <Wrench size={15} />
                             </button>
                         )}
-
                         {/* Header Menu */}
                         <div className="relative">
                             <button
@@ -727,11 +759,6 @@ const AgentInterface = () => {
                                                     onClick={() => { if (activeSession) { setSessionToClear(activeSession.id); setIsClearModalOpen(true); } setIsHeaderMenuOpen(false); }}
                                                     className="w-full text-left px-4 py-3 text-sm text-slate-200 hover:bg-slate-700/50 flex items-center gap-2"
                                                 ><Eraser size={15} />Clear History</button>
-                                                <div className="h-px bg-slate-700/50 mx-2" />
-                                                <button
-                                                    onClick={() => { fetchTools(); setIsHeaderMenuOpen(false); }}
-                                                    className="w-full text-left px-4 py-3 text-sm text-slate-200 hover:bg-slate-700/50 flex items-center gap-2"
-                                                ><RefreshCw size={15} />Refresh Tools</button>
                                             </motion.div>
                                         </>
                                     )}
@@ -904,13 +931,22 @@ const AgentInterface = () => {
                                     {systemTools.length + ownerTools.length}
                                 </span>
                             </div>
-                            <button
-                                onClick={fetchTools}
-                                className="p-1.5 rounded-lg text-slate-500 hover:text-emerald-400 hover:bg-slate-800 transition-colors"
-                                title="Refresh tools"
-                            >
-                                <RefreshCw size={13} className={loadingTools ? 'animate-spin' : ''} />
-                            </button>
+                            <div className="flex items-center gap-1">
+                                <button
+                                    onClick={fetchTools}
+                                    className="p-1.5 rounded-lg text-slate-500 hover:text-emerald-400 hover:bg-slate-800 transition-colors"
+                                    title="Refresh tools"
+                                >
+                                    <RefreshCw size={13} className={loadingTools ? 'animate-spin' : ''} />
+                                </button>
+                                <button
+                                    onClick={() => setShowToolsPanel(false)}
+                                    className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
+                                    title="Collapse tool store"
+                                >
+                                    <X size={13} />
+                                </button>
+                            </div>
                         </div>
 
                         <div className="flex-1 overflow-y-auto p-3 space-y-4 custom-scrollbar">
@@ -967,15 +1003,13 @@ const AgentInterface = () => {
                             )}
                         </div>
 
-                        {/* Future: Create Tool Button */}
                         <div className="p-3 border-t border-slate-700/50">
                             <button
-                                disabled
-                                className="w-full flex items-center justify-center gap-2 p-2.5 rounded-xl border border-dashed border-slate-700/50 text-slate-600 text-xs cursor-not-allowed hover:border-slate-600 transition-colors"
-                                title="Coming soon"
+                                onClick={() => setIsCreateToolModalOpen(true)}
+                                className="w-full flex items-center justify-center gap-2 p-2.5 rounded-xl border border-dashed border-violet-500/30 text-violet-400 text-xs hover:bg-violet-500/10 hover:border-violet-500/50 transition-colors"
                             >
                                 <Plus size={13} />
-                                Create Tool <span className="text-[10px] text-slate-700">(coming soon)</span>
+                                Create Tool
                             </button>
                         </div>
                     </motion.div>
@@ -1146,6 +1180,85 @@ const AgentInterface = () => {
                                 <div className="flex gap-3">
                                     <button onClick={() => setIsClearModalOpen(false)} className="flex-1 py-2.5 rounded-xl border border-slate-700/50 text-slate-400 hover:text-slate-200 text-sm font-medium transition-all">Cancel</button>
                                     <button onClick={handleClearSession} className="flex-1 py-2.5 rounded-xl bg-yellow-600 hover:bg-yellow-500 text-white text-sm font-medium transition-all">Clear</button>
+                                </div>
+                            </motion.div>
+                        </motion.div>
+                    )}
+                </AnimatePresence>,
+                document.body
+            )}
+            {/* ── Create Tool Modal ────────────────────────────────────────────── */}
+            {createPortal(
+                <AnimatePresence>
+                    {isCreateToolModalOpen && (
+                        <motion.div
+                            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200] flex items-center justify-center p-4"
+                            onClick={() => setIsCreateToolModalOpen(false)}
+                        >
+                            <motion.div
+                                initial={{ opacity: 0, scale: 0.95, y: 16 }}
+                                animate={{ opacity: 1, scale: 1, y: 0 }}
+                                exit={{ opacity: 0, scale: 0.95, y: 16 }}
+                                onClick={e => e.stopPropagation()}
+                                className="w-full max-w-md bg-slate-900 border border-slate-700/50 rounded-2xl shadow-2xl"
+                            >
+                                <div className="flex items-center justify-between p-6 border-b border-slate-700/50">
+                                    <div className="flex items-center gap-3">
+                                        <div className="w-9 h-9 rounded-xl bg-emerald-500/10 flex items-center justify-center">
+                                            <Wrench size={18} className="text-emerald-400" />
+                                        </div>
+                                        <h3 className="text-base font-semibold text-slate-100">Create Tool</h3>
+                                    </div>
+                                    <button onClick={() => setIsCreateToolModalOpen(false)} className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors">
+                                        <X size={16} />
+                                    </button>
+                                </div>
+                                <div className="p-6 space-y-4">
+                                    <div>
+                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">Tool Name <span className="text-red-400">*</span></label>
+                                        <input
+                                            type="text"
+                                            value={newToolName}
+                                            onChange={e => setNewToolName(e.target.value)}
+                                            placeholder="e.g. my_current_time"
+                                            autoFocus
+                                            className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all font-mono"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">Description <span className="text-slate-600">(optional)</span></label>
+                                        <input
+                                            type="text"
+                                            value={newToolDesc}
+                                            onChange={e => setNewToolDesc(e.target.value)}
+                                            placeholder="What does this tool do?"
+                                            className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">Webhook URL <span className="text-red-400">*</span></label>
+                                        <input
+                                            type="url"
+                                            value={newToolWebhookUrl}
+                                            onChange={e => setNewToolWebhookUrl(e.target.value)}
+                                            placeholder="https://your-server/tools/endpoint"
+                                            className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all font-mono"
+                                        />
+                                    </div>
+                                </div>
+                                <div className="flex gap-3 p-6 pt-0">
+                                    <button
+                                        onClick={() => setIsCreateToolModalOpen(false)}
+                                        className="flex-1 py-2.5 rounded-xl border border-slate-700/50 text-slate-400 hover:text-slate-200 hover:bg-slate-800/50 text-sm font-medium transition-all"
+                                    >Cancel</button>
+                                    <button
+                                        onClick={handleCreateTool}
+                                        disabled={!newToolName.trim() || !newToolWebhookUrl.trim() || isCreatingTool}
+                                        className="flex-1 py-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:opacity-50 disabled:cursor-not-allowed text-white text-sm font-medium transition-all shadow-lg shadow-emerald-900/30"
+                                    >
+                                        {isCreatingTool ? 'Creating…' : 'Create Tool'}
+                                    </button>
                                 </div>
                             </motion.div>
                         </motion.div>

--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -790,10 +790,10 @@ const AgentInterface = () => {
                         {!isMobile && !showToolsPanel && (
                             <button
                                 onClick={() => setShowToolsPanel(true)}
-                                className="p-1.5 rounded-lg text-slate-500 hover:text-emerald-400 hover:bg-slate-800 transition-colors"
+                                className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
                                 title="Open tool store"
                             >
-                                <Wrench size={15} />
+                                <ChevronLeft size={15} />
                             </button>
                         )}
                         {/* Header Menu */}
@@ -1020,7 +1020,7 @@ const AgentInterface = () => {
                                     className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
                                     title="Collapse tool store"
                                 >
-                                    <X size={13} />
+                                    <ChevronRight size={14} />
                                 </button>
                             </div>
                         </div>

--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -289,7 +289,7 @@ const AgentInterface = () => {
         setEditingSessionId(session.id);
         setNewSessionTitle(session.title);
         setNewSessionDesc(session.description || '');
-        setNewSessionModel(session.model || availableModels[0]?.name || '');
+        setNewSessionModel(session.model_name || session.model || availableModels[0]?.name || '');
         setNewSessionTools(session.tools || []);
         setIsCreateModalOpen(true);
     };
@@ -302,7 +302,7 @@ const AgentInterface = () => {
             session_type: 'text',
             title: newSessionTitle.trim() || 'New Agent Session',
             description: newSessionDesc.trim() || '',
-            model: newSessionModel,
+            model_name: newSessionModel,
             metadata: { tools: newSessionTools }
         };
 
@@ -343,6 +343,7 @@ const AgentInterface = () => {
                             ...s,
                             title: payload.title,
                             description: payload.description,
+                            model_name: payload.model_name,
                             tools: newSessionTools
                         };
                     }
@@ -1165,26 +1166,55 @@ const AgentInterface = () => {
                                     </div>
                                     <div>
                                         <label className="block text-xs font-medium text-slate-400 mb-1.5">Tool store</label>
-                                        <div className="bg-slate-800/40 border border-slate-700/30 rounded-xl overflow-y-auto max-h-40 custom-scrollbar p-1">
-                                            {[...systemTools, ...ownerTools].length === 0 ? (
+                                        <div className="bg-slate-800/40 border border-slate-700/30 rounded-xl overflow-y-auto max-h-48 custom-scrollbar p-1">
+                                            {systemTools.length === 0 && ownerTools.length === 0 ? (
                                                 <div className="p-3 text-center text-[11px] text-slate-500">No tools found.</div>
-                                            ) : [...systemTools, ...ownerTools].map(t => {
-                                                const isSelected = newSessionTools.includes(t.name);
-                                                return (
-                                                    <div
-                                                        key={t.name}
-                                                        onClick={() => setNewSessionTools(prev => prev.includes(t.name) ? prev.filter(name => name !== t.name) : [...prev, t.name])}
-                                                        className={`flex items-center gap-3 p-2 hover:bg-slate-800/60 rounded-lg cursor-pointer transition-colors group select-none ${isSelected ? 'bg-slate-800/30' : ''}`}
-                                                    >
-                                                        <div className={`w-4 h-4 rounded flex items-center justify-center shrink-0 border transition-all ${isSelected ? 'bg-violet-500 border-violet-500' : 'border-slate-600 group-hover:border-violet-400'}`}>
-                                                            {isSelected && <Check size={12} className="text-white" strokeWidth={3} />}
-                                                        </div>
-                                                        <div className="flex-1 min-w-0">
-                                                            <p className="text-xs font-medium text-slate-300 font-mono truncate">{t.name}</p>
-                                                        </div>
-                                                    </div>
-                                                );
-                                            })}
+                                            ) : (
+                                                <>
+                                                    {systemTools.length > 0 && (
+                                                        <>
+                                                            <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider px-2 pt-1.5 pb-1">System</p>
+                                                            {systemTools.map(t => {
+                                                                const isSelected = newSessionTools.includes(t.name);
+                                                                return (
+                                                                    <div
+                                                                        key={t.name}
+                                                                        onClick={() => setNewSessionTools(prev => prev.includes(t.name) ? prev.filter(n => n !== t.name) : [...prev, t.name])}
+                                                                        className={`flex items-center gap-3 p-2 hover:bg-slate-800/60 rounded-lg cursor-pointer transition-colors group select-none ${isSelected ? 'bg-slate-800/30' : ''}`}
+                                                                    >
+                                                                        <div className={`w-4 h-4 rounded flex items-center justify-center shrink-0 border transition-all ${isSelected ? 'bg-violet-500 border-violet-500' : 'border-slate-600 group-hover:border-violet-400'}`}>
+                                                                            {isSelected && <Check size={12} className="text-white" strokeWidth={3} />}
+                                                                        </div>
+                                                                        <p className="text-xs font-medium text-slate-300 font-mono truncate flex-1 min-w-0">{t.name}</p>
+                                                                    </div>
+                                                                );
+                                                            })}
+                                                        </>
+                                                    )}
+                                                    {ownerTools.length > 0 && (
+                                                        <>
+                                                            <p className="text-[10px] font-semibold text-slate-500 uppercase tracking-wider px-2 pt-2 pb-1">
+                                                                {localStorage.getItem('username') || 'User'}
+                                                            </p>
+                                                            {ownerTools.map(t => {
+                                                                const isSelected = newSessionTools.includes(t.name);
+                                                                return (
+                                                                    <div
+                                                                        key={t.name}
+                                                                        onClick={() => setNewSessionTools(prev => prev.includes(t.name) ? prev.filter(n => n !== t.name) : [...prev, t.name])}
+                                                                        className={`flex items-center gap-3 p-2 hover:bg-slate-800/60 rounded-lg cursor-pointer transition-colors group select-none ${isSelected ? 'bg-slate-800/30' : ''}`}
+                                                                    >
+                                                                        <div className={`w-4 h-4 rounded flex items-center justify-center shrink-0 border transition-all ${isSelected ? 'bg-violet-500 border-violet-500' : 'border-slate-600 group-hover:border-violet-400'}`}>
+                                                                            {isSelected && <Check size={12} className="text-white" strokeWidth={3} />}
+                                                                        </div>
+                                                                        <p className="text-xs font-medium text-slate-300 font-mono truncate flex-1 min-w-0">{t.name}</p>
+                                                                    </div>
+                                                                );
+                                                            })}
+                                                        </>
+                                                    )}
+                                                </>
+                                            )}
                                         </div>
                                         <p className="text-[10px] text-slate-500 mt-2 px-1 text-right">
                                             {newSessionTools.length} tool{newSessionTools.length !== 1 ? 's' : ''} selected

--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import {
-    Send, Bot, User, Plus, Trash2, Eraser, ChevronLeft, MoreVertical,
+    Send, Bot, User, Plus, Trash2, Eraser, ChevronLeft, ChevronRight, MoreVertical,
     Copy, Check, Search, Settings, Wrench, Zap,
     Terminal, Play, Square, RefreshCw, Info, Cpu, X, AlertCircle
 } from 'lucide-react';
@@ -103,6 +103,9 @@ const AgentInterface = () => {
     const [ownerTools, setOwnerTools] = useState([]);
     const [loadingTools, setLoadingTools] = useState(true);
     const [showToolsPanel, setShowToolsPanel] = useState(true);
+    const [isSessionListOpen, setIsSessionListOpen] = useState(true);
+    const [hoveredSession, setHoveredSession] = useState(null);
+    const [sessionTitleOverflow, setSessionTitleOverflow] = useState(0);
 
     // Mobile
     const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
@@ -591,7 +594,7 @@ const AgentInterface = () => {
     };
 
     // ── Render ─────────────────────────────────────────────────────────────────
-    const showSessionList = !isMobile || mobileView === 'list';
+    const showSessionList = isMobile ? mobileView === 'list' : isSessionListOpen;
     const showChatArea = !isMobile || mobileView === 'chat';
     const filteredSessions = sessions.filter(s =>
         s.title.toLowerCase().includes(searchQuery.toLowerCase())
@@ -601,80 +604,127 @@ const AgentInterface = () => {
         <div className="flex h-full w-full bg-slate-900 text-slate-100 overflow-hidden relative">
 
             {/* ── Left: Session List ──────────────────────────────────────────── */}
-            <div className={`${showSessionList ? 'flex' : 'hidden'} ${isMobile ? 'w-full pt-16' : 'w-64'} bg-slate-900/90 border-r border-slate-700/50 flex-col flex-shrink-0 backdrop-blur-xl`}>
-                <div className="p-4 space-y-3">
-                    <button
-                        id="agent-new-session-btn"
-                        onClick={handleOpenCreateModal}
-                        className="w-full flex items-center justify-center gap-2 bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-500 hover:to-purple-500 text-white p-3 rounded-xl transition-all shadow-lg shadow-violet-900/30 group"
+            <AnimatePresence initial={false}>
+                {showSessionList && (
+                    <motion.div
+                        initial={isMobile ? false : { width: 0, opacity: 0 }}
+                        animate={isMobile ? {} : { width: 200, opacity: 1 }}
+                        exit={isMobile ? {} : { width: 0, opacity: 0 }}
+                        transition={{ duration: 0.25, ease: 'easeInOut' }}
+                        className={`${isMobile ? 'w-full pt-16' : ''} bg-slate-900/90 border-r border-slate-700/50 flex flex-col flex-shrink-0 backdrop-blur-xl overflow-hidden`}
                     >
-                        <Plus size={18} className="group-hover:rotate-90 transition-transform duration-300" />
-                        <span className="font-medium text-sm">New Agent Session</span>
-                    </button>
-                    <div className="relative">
-                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" size={14} />
-                        <input
-                            type="text"
-                            placeholder="Search sessions..."
-                            value={searchQuery}
-                            onChange={e => setSearchQuery(e.target.value)}
-                            className="w-full bg-slate-800/50 border border-slate-700/50 rounded-xl py-2 pl-8 pr-3 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-violet-500/50 transition-all"
-                        />
-                    </div>
-                </div>
+                        <div className="p-2.5 space-y-2">
+                            <div className="flex items-center justify-between gap-2">
+                                <button
+                                    id="agent-new-session-btn"
+                                    onClick={handleOpenCreateModal}
+                                    className="flex-1 flex items-center justify-center gap-1.5 bg-gradient-to-r from-violet-600 to-purple-600 hover:from-violet-500 hover:to-purple-500 text-white py-2 px-3 rounded-lg transition-all shadow-md shadow-violet-900/30 group"
+                                >
+                                    <Plus size={14} className="group-hover:rotate-90 transition-transform duration-300 shrink-0" />
+                                    <span className="font-medium text-xs whitespace-nowrap">New Session</span>
+                                </button>
+                                {!isMobile && (
+                                    <button
+                                        onClick={() => setIsSessionListOpen(false)}
+                                        className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors shrink-0"
+                                        title="Collapse session list"
+                                    >
+                                        <ChevronLeft size={14} />
+                                    </button>
+                                )}
+                            </div>
+                            <div className="relative">
+                                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-500" size={12} />
+                                <input
+                                    type="text"
+                                    placeholder="Search..."
+                                    value={searchQuery}
+                                    onChange={e => setSearchQuery(e.target.value)}
+                                    className="w-full bg-slate-800/50 border border-slate-700/50 rounded-lg py-1.5 pl-7 pr-2.5 text-xs text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-violet-500/50 transition-all"
+                                />
+                            </div>
+                        </div>
 
-                <div className="flex-1 overflow-y-auto px-2 space-y-1 custom-scrollbar pb-4">
-                    {filteredSessions.length === 0 && (
-                        <div className="flex flex-col items-center justify-center py-12 text-slate-600 gap-3">
-                            <Bot size={32} className="opacity-40" />
-                            <p className="text-xs text-center">No sessions yet.<br />Create one to get started.</p>
-                        </div>
-                    )}
-                    {filteredSessions.map(session => (
-                        <div
-                            key={session.id}
-                            onClick={() => handleSelectSession(session.id)}
-                            className={`group flex items-center justify-between p-3 rounded-xl cursor-pointer transition-all border ${activeSessionId === session.id
-                                ? 'bg-violet-900/30 border-violet-700/50 text-white shadow-md'
-                                : 'border-transparent text-slate-400 hover:bg-slate-800/50 hover:text-slate-200'
-                                }`}
-                        >
-                            <div className="flex items-center gap-2.5 overflow-hidden flex-1">
-                                <div className={`w-7 h-7 rounded-lg flex items-center justify-center shrink-0 ${activeSessionId === session.id ? 'bg-violet-500/20' : 'bg-slate-800'}`}>
-                                    <Zap size={14} className={activeSessionId === session.id ? 'text-violet-400' : 'text-slate-600'} />
+                        <div className="flex-1 overflow-y-auto px-1.5 space-y-0.5 custom-scrollbar pb-3">
+                            {filteredSessions.length === 0 && (
+                                <div className="flex flex-col items-center justify-center py-10 text-slate-600 gap-2">
+                                    <Bot size={24} className="opacity-40" />
+                                    <p className="text-[11px] text-center">No sessions yet.</p>
                                 </div>
-                                <span className="truncate text-sm font-medium">{session.title}</span>
-                            </div>
-                            <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-                                <button
-                                    onClick={e => { e.stopPropagation(); handleOpenEditModal(session); }}
-                                    className="p-1.5 rounded-md hover:bg-violet-500/10 hover:text-violet-400 transition-colors"
-                                    title="Edit Session"
-                                ><Settings size={12} /></button>
-                                <button
-                                    onClick={e => { e.stopPropagation(); setSessionToClear(session.id); setIsClearModalOpen(true); }}
-                                    className="p-1.5 rounded-md hover:bg-yellow-500/10 hover:text-yellow-400 transition-colors"
-                                    title="Clear History"
-                                ><Eraser size={12} /></button>
-                                <button
-                                    onClick={e => { e.stopPropagation(); setSessionToDelete(session.id); setIsDeleteModalOpen(true); }}
-                                    className="p-1.5 rounded-md hover:bg-red-500/10 hover:text-red-400 transition-colors"
-                                    title="Delete Session"
-                                ><Trash2 size={12} /></button>
-                            </div>
+                            )}
+                            {filteredSessions.map(session => (
+                                <div
+                                    key={session.id}
+                                    onClick={() => handleSelectSession(session.id)}
+                                    onMouseEnter={e => {
+                                        const span = e.currentTarget.querySelector('[data-title-span]');
+                                        if (span) setSessionTitleOverflow(Math.max(0, span.scrollWidth - span.offsetWidth));
+                                        setHoveredSession(session.id);
+                                    }}
+                                    onMouseLeave={() => { setHoveredSession(null); setSessionTitleOverflow(0); }}
+                                    className={`group flex items-center justify-between px-2 py-1.5 rounded-lg cursor-pointer transition-all border ${activeSessionId === session.id
+                                        ? 'bg-violet-900/30 border-violet-700/50 text-white'
+                                        : 'border-transparent text-slate-400 hover:bg-slate-800/50 hover:text-slate-200'
+                                        }`}
+                                >
+                                    <div className="flex items-center gap-2 overflow-hidden flex-1">
+                                        <div className={`w-5 h-5 rounded-md flex items-center justify-center shrink-0 ${activeSessionId === session.id ? 'bg-violet-500/20' : 'bg-slate-800'}`}>
+                                            <Zap size={11} className={activeSessionId === session.id ? 'text-violet-400' : 'text-slate-600'} />
+                                        </div>
+                                        <span
+                                            data-title-span
+                                            className="text-xs font-medium whitespace-nowrap"
+                                            style={hoveredSession === session.id && sessionTitleOverflow > 0 ? {
+                                                display: 'inline-block',
+                                                animation: `marquee-session ${Math.max(1.5, sessionTitleOverflow / 40)}s ease-in-out infinite alternate`,
+                                                '--marquee-dist': `-${sessionTitleOverflow}px`,
+                                            } : {
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                display: 'block',
+                                            }}
+                                        >{session.title}</span>
+                                    </div>
+                                    <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                                        <button
+                                            onClick={e => { e.stopPropagation(); handleOpenEditModal(session); }}
+                                            className="p-1 rounded hover:bg-violet-500/10 hover:text-violet-400 transition-colors"
+                                            title="Edit"
+                                        ><Settings size={11} /></button>
+                                        <button
+                                            onClick={e => { e.stopPropagation(); setSessionToClear(session.id); setIsClearModalOpen(true); }}
+                                            className="p-1 rounded hover:bg-yellow-500/10 hover:text-yellow-400 transition-colors"
+                                            title="Clear"
+                                        ><Eraser size={11} /></button>
+                                        <button
+                                            onClick={e => { e.stopPropagation(); setSessionToDelete(session.id); setIsDeleteModalOpen(true); }}
+                                            className="p-1 rounded hover:bg-red-500/10 hover:text-red-400 transition-colors"
+                                            title="Delete"
+                                        ><Trash2 size={11} /></button>
+                                    </div>
+                                </div>
+                            ))}
                         </div>
-                    ))}
-                </div>
-            </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
 
             {/* ── Middle: Chat Area ───────────────────────────────────────────── */}
             <div className={`${showChatArea ? 'flex' : 'hidden'} flex-1 flex-col h-full relative overflow-hidden`}>
                 {/* Header */}
                 <div className={`h-16 border-b border-slate-700/50 flex items-center justify-between px-4 md:px-6 bg-slate-900/80 backdrop-blur-md sticky top-0 z-10 ${isMobile ? 'pl-16' : ''}`}>
                     <div className="flex items-center gap-3">
-                        {isMobile && (
+                        {isMobile ? (
                             <button onClick={() => setMobileView('list')} className="p-1 hover:bg-slate-800 rounded-lg text-slate-400">
                                 <ChevronLeft size={22} />
+                            </button>
+                        ) : !isSessionListOpen && (
+                            <button
+                                onClick={() => setIsSessionListOpen(true)}
+                                className="p-1.5 rounded-lg text-slate-500 hover:text-violet-400 hover:bg-slate-800 transition-colors"
+                                title="Open session list"
+                            >
+                                <ChevronRight size={15} />
                             </button>
                         )}
                         <div className="w-9 h-9 rounded-full bg-violet-500/20 flex items-center justify-center">

--- a/src/components/AgentInterface.jsx
+++ b/src/components/AgentInterface.jsx
@@ -117,7 +117,10 @@ const AgentInterface = () => {
     const [editingSessionId, setEditingSessionId] = useState(null);
     const [newSessionTitle, setNewSessionTitle] = useState('');
     const [newSessionDesc, setNewSessionDesc] = useState('');
+    const [newSessionModel, setNewSessionModel] = useState('');
     const [newSessionTools, setNewSessionTools] = useState([]);
+    const [availableModels, setAvailableModels] = useState([]);
+    const [loadingModels, setLoadingModels] = useState(false);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [sessionToDelete, setSessionToDelete] = useState(null);
     const [isClearModalOpen, setIsClearModalOpen] = useState(false);
@@ -144,6 +147,7 @@ const AgentInterface = () => {
     useEffect(() => {
         fetchTools();
         fetchSessions();
+        fetchModels();
     }, []);
 
     useEffect(() => {
@@ -187,6 +191,25 @@ const AgentInterface = () => {
             setOwnerTools([]);
         } finally {
             setLoadingTools(false);
+        }
+    };
+
+    // ── Fetch Models ──────────────────────────────────────────────────────────
+    const fetchModels = async () => {
+        setLoadingModels(true);
+        try {
+            const res = await fetch('/llm_openai/models');
+            if (!res.ok) throw new Error();
+            const data = await res.json();
+            const models = data.models || [];
+            setAvailableModels(models);
+            if (models.length > 0) setNewSessionModel(models[0].name);
+        } catch {
+            const fallback = [{ name: 'gpt-4o' }, { name: 'gpt-4o-mini' }];
+            setAvailableModels(fallback);
+            setNewSessionModel(fallback[0].name);
+        } finally {
+            setLoadingModels(false);
         }
     };
 
@@ -266,6 +289,7 @@ const AgentInterface = () => {
         setEditingSessionId(session.id);
         setNewSessionTitle(session.title);
         setNewSessionDesc(session.description || '');
+        setNewSessionModel(session.model || availableModels[0]?.name || '');
         setNewSessionTools(session.tools || []);
         setIsCreateModalOpen(true);
     };
@@ -278,6 +302,7 @@ const AgentInterface = () => {
             session_type: 'text',
             title: newSessionTitle.trim() || 'New Agent Session',
             description: newSessionDesc.trim() || '',
+            model: newSessionModel,
             metadata: { tools: newSessionTools }
         };
 
@@ -327,6 +352,7 @@ const AgentInterface = () => {
             setIsCreateModalOpen(false);
             setNewSessionTitle('');
             setNewSessionDesc('');
+            setNewSessionModel(availableModels[0]?.name || '');
             setEditingSessionId(null);
             setModalMode('create');
         } catch (error) {
@@ -1117,6 +1143,25 @@ const AgentInterface = () => {
                                             rows={2}
                                             className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-violet-500/50 transition-all resize-none"
                                         />
+                                    </div>
+                                    <div>
+                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">LLM Model</label>
+                                        {loadingModels ? (
+                                            <div className="flex items-center gap-2 text-xs text-slate-500 py-2.5">
+                                                <RefreshCw size={12} className="animate-spin" />
+                                                Loading models...
+                                            </div>
+                                        ) : (
+                                            <select
+                                                value={newSessionModel}
+                                                onChange={e => setNewSessionModel(e.target.value)}
+                                                className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-violet-500/50 transition-all appearance-none cursor-pointer"
+                                            >
+                                                {availableModels.map(m => (
+                                                    <option key={m.name} value={m.name}>{m.name}</option>
+                                                ))}
+                                            </select>
+                                        )}
                                     </div>
                                     <div>
                                         <label className="block text-xs font-medium text-slate-400 mb-1.5">Tool store</label>

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -200,7 +200,7 @@ const ChatInterface = () => {
                     messages: s.messages || [],
                     timestamp: s.created_at || s.timestamp || new Date(),
                     model: s.model_name || s.model || 'gpt-5-nano',
-                    type: s.session_type || s.type || 'text'
+                    type: (s.session_type === 'voice' ? 'audio' : s.session_type) || s.type || 'text'
                 }));
 
                 const sortedSessions = formattedSessions.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
@@ -361,7 +361,7 @@ const ChatInterface = () => {
                 const payload = {
                     owner: username,
                     mode: 'chat',
-                    session_type: selectedType,
+                    session_type: selectedType === 'audio' ? 'voice' : selectedType,
                     title: newSessionTitle || 'New Chat',
                     description: newSessionDescription || 'New conversation started',
                     model_name: selectedModel,
@@ -391,7 +391,7 @@ const ChatInterface = () => {
                     // Map backend 'model_name' to frontend 'model' if necessary, 
                     // though the frontend uses 'model' property in some places
                     model: createdSession.model_name || createdSession.model || selectedModel,
-                    type: createdSession.session_type || selectedType
+                    type: (createdSession.session_type === 'voice' ? 'audio' : createdSession.session_type) || selectedType
                 };
 
                 setSessions(prev => [newSession, ...prev]);
@@ -412,7 +412,7 @@ const ChatInterface = () => {
                     title: newSessionTitle,
                     description: newSessionDescription,
                     model_name: selectedModel,
-                    session_type: selectedType,
+                    session_type: selectedType === 'audio' ? 'voice' : selectedType,
                     metadata: selectedType === 'audio' ? { voice: selectedVoice } : {}
                 };
 
@@ -434,7 +434,7 @@ const ChatInterface = () => {
                             ...s,
                             ...updatedData,
                             model: updatedData.model_name || updatedData.model || selectedModel,
-                            type: updatedData.session_type || selectedType,
+                            type: (updatedData.session_type === 'voice' ? 'audio' : updatedData.session_type) || selectedType,
                             timestamp: updatedData.created_at || s.timestamp
                         }
                         : s
@@ -542,7 +542,7 @@ const ChatInterface = () => {
                     title: editTitleValue || 'Untitled',
                     description: session.description || '',
                     model_name: session.model_name || session.model || 'gpt-5-nano',
-                    session_type: session.session_type || session.type || 'text',
+                    session_type: (session.session_type || session.type || 'text') === 'audio' ? 'voice' : (session.session_type || session.type || 'text'),
                     metadata: session.metadata || (session.type === 'audio' ? { voice: session.voice } : {})
                 };
                 const response = await fetch(`/chat_session/${editingSessionId}`, {
@@ -709,7 +709,7 @@ const ChatInterface = () => {
                         title: generatedTitle,
                         description: activeSession.description || 'New conversation started',
                         model_name: activeSession.model_name || activeSession.model || "gpt-5-nano",
-                        session_type: activeSession.session_type || activeSession.type || "text",
+                        session_type: (activeSession.session_type || activeSession.type || "text") === 'audio' ? 'voice' : (activeSession.session_type || activeSession.type || "text"),
                         metadata: activeSession.metadata || (activeSession.type === 'audio' ? { voice: activeSession.voice } : {})
                     };
                     await fetch(`/chat_session/${activeSessionId}`, {

--- a/src/components/ChatInterface.jsx
+++ b/src/components/ChatInterface.jsx
@@ -1018,79 +1018,79 @@ const ChatInterface = () => {
     return (
         <div className="flex h-full w-full bg-slate-900 text-text overflow-hidden relative">
             {/* Sessions Sidebar / List View */}
-            <div className={`${showSessionList ? 'flex' : 'hidden'} ${isMobile ? 'w-full pt-16' : 'w-64'} bg-slate-900/90 border-r border-slate-700/50 flex flex-col flex-shrink-0 backdrop-blur-xl transition-all duration-300`}>
-                <div className="p-4">
+            <div className={`${showSessionList ? 'flex' : 'hidden'} ${isMobile ? 'w-full pt-16' : 'w-[200px]'} bg-slate-900/90 border-r border-slate-700/50 flex flex-col flex-shrink-0 backdrop-blur-xl transition-all duration-300`}>
+                <div className="p-2.5 space-y-2">
                     <button
                         onClick={handleOpenCreateModal}
-                        className="w-full flex items-center justify-center gap-2 bg-blue-600 hover:bg-blue-500 text-white p-3 rounded-xl transition-all shadow-lg shadow-blue-900/20 group"
+                        className="w-full flex items-center justify-center gap-1.5 bg-blue-600 hover:bg-blue-500 text-white py-2 px-3 rounded-lg transition-all shadow-md shadow-blue-900/20 group"
                     >
-                        <Plus size={20} className="group-hover:rotate-90 transition-transform duration-300" />
-                        <span className="font-medium">New Chat</span>
+                        <Plus size={14} className="group-hover:rotate-90 transition-transform duration-300 shrink-0" />
+                        <span className="font-medium text-xs whitespace-nowrap">New Chat</span>
                     </button>
                     {isMobile && (
-                        <p className="text-center text-xs text-slate-500 mt-4">Select a chat to start messaging</p>
+                        <p className="text-center text-xs text-slate-500">Select a chat to start messaging</p>
                     )}
 
                     {/* Search Bar */}
-                    <div className="relative mt-3">
-                        <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-500" size={16} />
+                    <div className="relative">
+                        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-500" size={12} />
                         <input
                             type="text"
                             placeholder="Search chats..."
                             value={searchQuery}
                             onChange={(e) => setSearchQuery(e.target.value)}
-                            className="w-full bg-slate-800/50 border border-slate-700/50 rounded-xl py-2 pl-9 pr-3 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all"
+                            className="w-full bg-slate-800/50 border border-slate-700/50 rounded-lg py-1.5 pl-7 pr-2.5 text-xs text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 transition-all"
                         />
                     </div>
                 </div>
 
-                <div className="flex-1 overflow-y-auto px-2 space-y-1 custom-scrollbar">
+                <div className="flex-1 overflow-y-auto px-1.5 space-y-0.5 custom-scrollbar pb-3">
                     {sessions.filter(session => session.title.toLowerCase().includes(searchQuery.toLowerCase())).map(session => (
                         <div
                             key={session.id}
                             onClick={() => handleSessionSelect(session.id)}
                             onMouseEnter={(e) => handleSessionHover(e, session.id)}
                             onMouseLeave={() => setHoveredSessionId(null)}
-                            className={`group flex items-center justify-between p-3 rounded-lg cursor-pointer transition-all border border-transparent relative ${activeSessionId === session.id
+                            className={`group flex items-center justify-between px-2 py-1.5 rounded-lg cursor-pointer transition-all border border-transparent relative ${activeSessionId === session.id
                                 ? 'bg-slate-800 text-white border-slate-700/50 shadow-md'
                                 : 'text-slate-400 hover:bg-slate-800/50 hover:text-slate-200'
                                 }`}
                         >
-                            <div className="flex items-center gap-3 overflow-hidden flex-1">
+                            <div className="flex items-center gap-2 overflow-hidden flex-1">
                                 {session.type === 'image' ? (
-                                    <ImageIcon size={18} className={`shrink-0 ${activeSessionId === session.id ? 'text-blue-400' : 'text-slate-600'}`} />
+                                    <ImageIcon size={14} className={`shrink-0 ${activeSessionId === session.id ? 'text-blue-400' : 'text-slate-600'}`} />
                                 ) : session.type === 'audio' ? (
-                                    <AudioWaveform size={18} className={`shrink-0 ${activeSessionId === session.id ? 'text-purple-400' : 'text-slate-600'}`} />
+                                    <AudioWaveform size={14} className={`shrink-0 ${activeSessionId === session.id ? 'text-purple-400' : 'text-slate-600'}`} />
                                 ) : (
-                                    <MessageSquare size={18} className={`shrink-0 ${activeSessionId === session.id ? 'text-blue-400' : 'text-slate-600'}`} />
+                                    <MessageSquare size={14} className={`shrink-0 ${activeSessionId === session.id ? 'text-blue-400' : 'text-slate-600'}`} />
                                 )}
-                                <span className="truncate text-sm font-medium">{session.title}</span>
+                                <span className="truncate text-xs font-medium">{session.title}</span>
                             </div>
-                            <div className="flex items-center gap-1 opacity-100 md:opacity-0 group-hover:opacity-100 transition-opacity">
+                            <div className="flex items-center gap-0.5 opacity-100 md:opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
                                 <button
                                     onClick={(e) => {
                                         handleSessionSelect(session.id);
                                         handleOpenEditModal(e, session);
                                     }}
-                                    className="p-1.5 rounded-md hover:bg-slate-700 hover:text-slate-200 transition-colors"
+                                    className="p-1 rounded hover:bg-slate-700 hover:text-slate-200 transition-colors"
                                     title="Settings"
                                 >
-                                    <Settings size={14} />
+                                    <Settings size={11} />
                                 </button>
                                 <button
                                     onClick={(e) => handleClearSession(e, session.id)}
-                                    className="p-1.5 rounded-md hover:bg-yellow-500/10 hover:text-yellow-400 transition-colors"
+                                    className="p-1 rounded hover:bg-yellow-500/10 hover:text-yellow-400 transition-colors"
                                     title="Clear Chat History"
                                 >
-                                    <Eraser size={14} />
+                                    <Eraser size={11} />
                                 </button>
                                 <button
                                     onClick={(e) => handleDeleteSession(e, session.id)}
-                                    className={`p-1.5 rounded-md hover:bg-red-500/10 hover:text-red-400 transition-colors ${sessions.length === 1 ? 'hidden' : ''
+                                    className={`p-1 rounded hover:bg-red-500/10 hover:text-red-400 transition-colors ${sessions.length === 1 ? 'hidden' : ''
                                         }`}
                                     title="Delete Chat"
                                 >
-                                    <Trash2 size={14} />
+                                    <Trash2 size={11} />
                                 </button>
                             </div>
                         </div>

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -149,11 +149,19 @@ const RagInterface = () => {
     // ── API helpers ───────────────────────────────────────────────────────────
     const fetchSessions = async () => {
         try {
-            const res = await fetch('/rag_session', { headers: { accept: 'application/json' } });
+            const username = localStorage.getItem('username') || 'regina';
+            const res = await fetch(`/chat_session/?owner=${username}&mode=rag`);
             if (!res.ok) throw new Error();
             const data = await res.json();
-            const list = Array.isArray(data) ? data : (data.sessions || []);
-            setSessions(list.map(s => ({ ...s, messages: s.messages || [] })));
+            const ragSessions = (Array.isArray(data) ? data : [])
+                .filter(s => s.mode === 'rag')
+                .map(s => ({
+                    ...s,
+                    messages: s.messages || [],
+                    timestamp: s.created_at || new Date().toISOString(),
+                }))
+                .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+            setSessions(ragSessions);
         } catch {
             setSessions([]);
         }
@@ -192,10 +200,18 @@ const RagInterface = () => {
         if (!newSessionTitle.trim() || isCreating) return;
         setIsCreating(true);
         try {
-            const res = await fetch('/rag_session', {
+            const username = localStorage.getItem('username') || 'regina';
+            const res = await fetch('/chat_session/', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ title: newSessionTitle.trim(), description: newSessionDesc.trim(), model: newSessionModel, mode: 'rag' }),
+                body: JSON.stringify({
+                    owner: username,
+                    mode: 'rag',
+                    session_type: 'text',
+                    title: newSessionTitle.trim(),
+                    description: newSessionDesc.trim(),
+                    model: newSessionModel,
+                }),
             });
             if (!res.ok) throw new Error();
             const created = await res.json();
@@ -218,7 +234,7 @@ const RagInterface = () => {
     const handleDeleteSession = async () => {
         if (!sessionToDelete) return;
         try {
-            await fetch(`/rag_session/${sessionToDelete}`, { method: 'DELETE' });
+            await fetch(`/chat_session/${sessionToDelete}`, { method: 'DELETE' });
         } catch { /* ignore */ }
         const remaining = sessions.filter(s => s.id !== sessionToDelete);
         setSessions(remaining);

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -86,6 +86,9 @@ const RagInterface = () => {
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
     const [newSessionTitle, setNewSessionTitle] = useState('');
     const [newSessionDesc, setNewSessionDesc] = useState('');
+    const [newSessionModel, setNewSessionModel] = useState('');
+    const [availableModels, setAvailableModels] = useState([]);
+    const [loadingModels, setLoadingModels] = useState(false);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [sessionToDelete, setSessionToDelete] = useState(null);
     const [isCreating, setIsCreating] = useState(false);
@@ -105,6 +108,7 @@ const RagInterface = () => {
     // ── Effects ──────────────────────────────────────────────────────────────
     useEffect(() => {
         fetchSessions();
+        fetchModels();
     }, []);
 
     useEffect(() => {
@@ -155,6 +159,24 @@ const RagInterface = () => {
         }
     };
 
+    const fetchModels = async () => {
+        setLoadingModels(true);
+        try {
+            const res = await fetch('/llm_openai/models');
+            if (!res.ok) throw new Error();
+            const data = await res.json();
+            const models = data.models || [];
+            setAvailableModels(models);
+            if (models.length > 0) setNewSessionModel(models[0].name);
+        } catch {
+            const fallback = [{ name: 'gpt-4o' }, { name: 'gpt-4o-mini' }];
+            setAvailableModels(fallback);
+            setNewSessionModel(fallback[0].name);
+        } finally {
+            setLoadingModels(false);
+        }
+    };
+
     const fetchFiles = async (sessionId) => {
         try {
             const res = await fetch(`/rag_session/${sessionId}/files`, { headers: { accept: 'application/json' } });
@@ -173,7 +195,7 @@ const RagInterface = () => {
             const res = await fetch('/rag_session', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ title: newSessionTitle.trim(), description: newSessionDesc.trim() }),
+                body: JSON.stringify({ title: newSessionTitle.trim(), description: newSessionDesc.trim(), model: newSessionModel }),
             });
             if (!res.ok) throw new Error();
             const created = await res.json();
@@ -184,6 +206,7 @@ const RagInterface = () => {
             setIsCreateModalOpen(false);
             setNewSessionTitle('');
             setNewSessionDesc('');
+            setNewSessionModel(availableModels[0]?.name || '');
             if (isMobile) setMobileView('chat');
         } catch (err) {
             console.error('Failed to create session:', err);
@@ -559,10 +582,10 @@ const RagInterface = () => {
                     </div>
 
                     {/* Messages */}
-                    <div className="flex-1 overflow-y-auto custom-scrollbar px-4 py-4 space-y-4">
+                    <div className="flex-1 overflow-y-auto custom-scrollbar flex flex-col px-4 py-4">
                         {!activeSession ? (
                             // Empty state — no session selected
-                            <div className="h-full flex flex-col items-center justify-center gap-4 text-slate-600">
+                            <div className="flex-1 flex flex-col items-center justify-center gap-4 text-slate-600">
                                 <div className="w-16 h-16 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center">
                                     <Database size={28} className="text-emerald-500/60" />
                                 </div>
@@ -580,7 +603,7 @@ const RagInterface = () => {
                             </div>
                         ) : messages.length === 0 ? (
                             // Session exists but no messages yet
-                            <div className="h-full flex flex-col items-center justify-center gap-3 text-slate-600">
+                            <div className="flex-1 flex flex-col items-center justify-center gap-3 text-slate-600">
                                 <div className="w-14 h-14 rounded-xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center">
                                     <Zap size={22} className="text-emerald-500/60" />
                                 </div>
@@ -590,7 +613,8 @@ const RagInterface = () => {
                                 </div>
                             </div>
                         ) : (
-                            messages.map(msg => (
+                            <div className="space-y-4">
+                            {messages.map(msg => (
                                 <div
                                     key={msg.id}
                                     className={`flex gap-3 ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
@@ -644,7 +668,8 @@ const RagInterface = () => {
                                         </span>
                                     </div>
                                 </div>
-                            ))
+                            ))}
+                            </div>
                         )}
                         <div ref={messagesEndRef} />
                     </div>
@@ -891,6 +916,25 @@ const RagInterface = () => {
                                             autoFocus
                                             className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-3 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all"
                                         />
+                                    </div>
+                                    <div>
+                                        <label className="text-xs text-slate-400 font-medium mb-1.5 block">LLM Model *</label>
+                                        {loadingModels ? (
+                                            <div className="flex items-center gap-2 text-xs text-slate-500 py-2.5">
+                                                <RefreshCw size={12} className="animate-spin" />
+                                                Loading models...
+                                            </div>
+                                        ) : (
+                                            <select
+                                                value={newSessionModel}
+                                                onChange={e => setNewSessionModel(e.target.value)}
+                                                className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-3 py-2.5 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all appearance-none cursor-pointer"
+                                            >
+                                                {availableModels.map(m => (
+                                                    <option key={m.name} value={m.name}>{m.name}</option>
+                                                ))}
+                                            </select>
+                                        )}
                                     </div>
                                     <div>
                                         <label className="text-xs text-slate-400 font-medium mb-1.5 block">Description</label>

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -885,28 +885,32 @@ const RagInterface = () => {
             {createPortal(
                 <AnimatePresence>
                     {isCreateModalOpen && (
-                        <>
+                        <motion.div
+                            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200] flex items-center justify-center p-4"
+                            onClick={() => setIsCreateModalOpen(false)}
+                        >
                             <motion.div
-                                initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-                                onClick={() => setIsCreateModalOpen(false)}
-                                className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200]"
-                            />
-                            <motion.div
-                                initial={{ opacity: 0, scale: 0.95, y: 10 }}
+                                initial={{ opacity: 0, scale: 0.95, y: 16 }}
                                 animate={{ opacity: 1, scale: 1, y: 0 }}
-                                exit={{ opacity: 0, scale: 0.95, y: 10 }}
-                                transition={{ duration: 0.15 }}
-                                className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md bg-slate-900 border border-slate-700/60 rounded-2xl shadow-2xl z-[201] p-6"
+                                exit={{ opacity: 0, scale: 0.95, y: 16 }}
+                                onClick={e => e.stopPropagation()}
+                                className="w-full max-w-md max-h-[90vh] bg-slate-900 border border-slate-700/50 rounded-2xl shadow-2xl overflow-y-auto"
                             >
-                                <h2 className="text-base font-bold text-slate-100 mb-4 flex items-center gap-2">
-                                    <div className="w-7 h-7 rounded-lg bg-emerald-500/20 flex items-center justify-center">
-                                        <Database size={14} className="text-emerald-400" />
+                                <div className="flex items-center justify-between p-6 border-b border-slate-700/50">
+                                    <div className="flex items-center gap-3">
+                                        <div className="w-9 h-9 rounded-xl bg-emerald-500/10 flex items-center justify-center">
+                                            <Database size={18} className="text-emerald-400" />
+                                        </div>
+                                        <h3 className="text-base font-semibold text-slate-100">New RAG Session</h3>
                                     </div>
-                                    New RAG Session
-                                </h2>
-                                <div className="space-y-3">
+                                    <button onClick={() => setIsCreateModalOpen(false)} className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors">
+                                        <X size={16} />
+                                    </button>
+                                </div>
+                                <div className="p-6 space-y-4">
                                     <div>
-                                        <label className="text-xs text-slate-400 font-medium mb-1.5 block">Session Name *</label>
+                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">Session Name *</label>
                                         <input
                                             type="text"
                                             value={newSessionTitle}
@@ -914,11 +918,11 @@ const RagInterface = () => {
                                             onKeyDown={e => e.key === 'Enter' && handleCreateSession()}
                                             placeholder="e.g. Product Documentation Q&A"
                                             autoFocus
-                                            className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-3 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all"
+                                            className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all"
                                         />
                                     </div>
                                     <div>
-                                        <label className="text-xs text-slate-400 font-medium mb-1.5 block">LLM Model *</label>
+                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">LLM Model *</label>
                                         {loadingModels ? (
                                             <div className="flex items-center gap-2 text-xs text-slate-500 py-2.5">
                                                 <RefreshCw size={12} className="animate-spin" />
@@ -928,7 +932,7 @@ const RagInterface = () => {
                                             <select
                                                 value={newSessionModel}
                                                 onChange={e => setNewSessionModel(e.target.value)}
-                                                className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-3 py-2.5 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all appearance-none cursor-pointer"
+                                                className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all appearance-none cursor-pointer"
                                             >
                                                 {availableModels.map(m => (
                                                     <option key={m.name} value={m.name}>{m.name}</option>
@@ -937,17 +941,17 @@ const RagInterface = () => {
                                         )}
                                     </div>
                                     <div>
-                                        <label className="text-xs text-slate-400 font-medium mb-1.5 block">Description</label>
+                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">Description</label>
                                         <textarea
                                             value={newSessionDesc}
                                             onChange={e => setNewSessionDesc(e.target.value)}
                                             placeholder="What documents will you upload? (optional)"
                                             rows={2}
-                                            className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-3 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all resize-none"
+                                            className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all resize-none"
                                         />
                                     </div>
                                 </div>
-                                <div className="flex justify-end gap-2 mt-5">
+                                <div className="flex justify-end gap-3 px-6 pb-6">
                                     <button
                                         onClick={() => setIsCreateModalOpen(false)}
                                         className="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 rounded-xl hover:bg-slate-800 transition-colors"
@@ -962,7 +966,7 @@ const RagInterface = () => {
                                     </button>
                                 </div>
                             </motion.div>
-                        </>
+                        </motion.div>
                     )}
                 </AnimatePresence>,
                 document.body
@@ -972,24 +976,25 @@ const RagInterface = () => {
             {createPortal(
                 <AnimatePresence>
                     {isDeleteModalOpen && (
-                        <>
+                        <motion.div
+                            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                            className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200] flex items-center justify-center p-4"
+                            onClick={() => setIsDeleteModalOpen(false)}
+                        >
                             <motion.div
-                                initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-                                onClick={() => setIsDeleteModalOpen(false)}
-                                className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200]"
-                            />
-                            <motion.div
-                                initial={{ opacity: 0, scale: 0.95, y: 10 }}
+                                initial={{ opacity: 0, scale: 0.95, y: 16 }}
                                 animate={{ opacity: 1, scale: 1, y: 0 }}
-                                exit={{ opacity: 0, scale: 0.95, y: 10 }}
-                                transition={{ duration: 0.15 }}
-                                className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-sm bg-slate-900 border border-slate-700/60 rounded-2xl shadow-2xl z-[201] p-6"
+                                exit={{ opacity: 0, scale: 0.95, y: 16 }}
+                                onClick={e => e.stopPropagation()}
+                                className="w-full max-w-sm bg-slate-900 border border-slate-700/50 rounded-2xl shadow-2xl"
                             >
-                                <h2 className="text-base font-bold text-slate-100 mb-2">Delete Session?</h2>
-                                <p className="text-sm text-slate-400 mb-5">
-                                    This will permanently delete the session, all messages, and all uploaded files.
-                                </p>
-                                <div className="flex justify-end gap-2">
+                                <div className="p-6">
+                                    <h2 className="text-base font-bold text-slate-100 mb-2">Delete Session?</h2>
+                                    <p className="text-sm text-slate-400">
+                                        This will permanently delete the session, all messages, and all uploaded files.
+                                    </p>
+                                </div>
+                                <div className="flex justify-end gap-3 px-6 pb-6">
                                     <button
                                         onClick={() => setIsDeleteModalOpen(false)}
                                         className="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 rounded-xl hover:bg-slate-800 transition-colors"
@@ -1000,7 +1005,7 @@ const RagInterface = () => {
                                     >Delete</button>
                                 </div>
                             </motion.div>
-                        </>
+                        </motion.div>
                     )}
                 </AnimatePresence>,
                 document.body

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -128,7 +128,7 @@ const RagInterface = () => {
 
     useEffect(() => {
         if (activeSessionId) {
-            fetchFiles(activeSessionId);
+            fetchFiles();
         }
     }, [activeSessionId]);
 
@@ -185,12 +185,22 @@ const RagInterface = () => {
         }
     };
 
-    const fetchFiles = async (sessionId) => {
+    const fetchFiles = async () => {
         try {
-            const res = await fetch(`/rag_session/${sessionId}/files`, { headers: { accept: 'application/json' } });
+            const owner = localStorage.getItem('username') || 'regina';
+            const res = await fetch(`/documents?collection=documents&owner=${owner}`, {
+                headers: { accept: 'application/json' },
+            });
             if (!res.ok) throw new Error();
             const data = await res.json();
-            setFiles(Array.isArray(data) ? data : (data.files || []));
+            // Deduplicate by filename — API returns one entry per chunk
+            const seen = new Set();
+            const unique = (Array.isArray(data) ? data : []).filter(d => {
+                if (seen.has(d.filename)) return false;
+                seen.add(d.filename);
+                return true;
+            });
+            setFiles(unique.map(d => ({ id: d.doc_id, name: d.filename, status: 'ready' })));
         } catch {
             setFiles([]);
         }
@@ -385,7 +395,7 @@ const RagInterface = () => {
         if (!allowed.some(ext => file.name.toLowerCase().endsWith(ext))) return;
 
         const tempId = `f-${Date.now()}-${Math.random()}`;
-        setFiles(prev => [...prev, { id: tempId, name: file.name, size: file.size, status: 'uploading', progress: 0 }]);
+        setFiles(prev => [...prev, { id: tempId, name: file.name, status: 'uploading', progress: 0 }]);
 
         const progressInterval = setInterval(() => {
             setFiles(prev => prev.map(f =>
@@ -394,36 +404,25 @@ const RagInterface = () => {
         }, 150);
 
         try {
+            const owner = localStorage.getItem('username') || 'regina';
             const formData = new FormData();
             formData.append('file', file);
-            const res = await fetch(`/rag_session/${activeSessionId}/files`, {
+            formData.append('collection', 'documents');
+            formData.append('owner', owner);
+            formData.append('chunk_size', '500');
+            formData.append('chunk_overlap', '50');
+
+            const res = await fetch('/documents/upload', {
                 method: 'POST',
+                headers: { accept: 'application/json' },
                 body: formData,
             });
             clearInterval(progressInterval);
             if (!res.ok) throw new Error();
-            const data = await res.json();
+            // Upload is synchronous — file is indexed immediately
             setFiles(prev => prev.map(f =>
-                f.id === tempId
-                    ? { id: data.id, name: data.name || file.name, size: data.size || file.size, status: 'indexing', progress: 100 }
-                    : f
+                f.id === tempId ? { ...f, id: file.name, status: 'ready', progress: 100 } : f
             ));
-            // Poll for indexing completion
-            const pollId = data.id;
-            const poll = setInterval(async () => {
-                try {
-                    const statusRes = await fetch(`/rag_session/${activeSessionId}/files/${pollId}`);
-                    if (!statusRes.ok) { clearInterval(poll); return; }
-                    const statusData = await statusRes.json();
-                    if (statusData.status === 'ready') {
-                        setFiles(prev => prev.map(f => f.id === pollId ? { ...f, status: 'ready' } : f));
-                        clearInterval(poll);
-                    } else if (statusData.status === 'error') {
-                        setFiles(prev => prev.map(f => f.id === pollId ? { ...f, status: 'error' } : f));
-                        clearInterval(poll);
-                    }
-                } catch { clearInterval(poll); }
-            }, 2000);
         } catch {
             clearInterval(progressInterval);
             setFiles(prev => prev.map(f =>
@@ -432,11 +431,7 @@ const RagInterface = () => {
         }
     }, [activeSessionId]);
 
-    const handleDeleteFile = async (fileId) => {
-        if (!activeSessionId) return;
-        try {
-            await fetch(`/rag_session/${activeSessionId}/files/${fileId}`, { method: 'DELETE' });
-        } catch { /* ignore */ }
+    const handleDeleteFile = (fileId) => {
         setFiles(prev => prev.filter(f => f.id !== fileId));
     };
 

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -1,0 +1,968 @@
+import React, { useState, useEffect, useRef, useCallback } from 'react';
+import { createPortal } from 'react-dom';
+import { motion, AnimatePresence } from 'framer-motion';
+import {
+    Plus, Search, ChevronLeft, ChevronRight, X, Send, Square,
+    Database, FileText, Upload, Trash2, RefreshCw, Check,
+    AlertCircle, Copy, CheckCheck, MoreVertical, Zap, Bot,
+    Info
+} from 'lucide-react';
+import classNames from 'classnames';
+import { useNavigate, useParams } from 'react-router-dom';
+
+// ── Source citation pill ────────────────────────────────────────────────────
+const SourcePill = ({ source, onClick }) => (
+    <button
+        onClick={() => onClick(source)}
+        className="inline-flex items-center gap-1 text-[11px] font-medium text-emerald-300 bg-emerald-950/40 border border-emerald-500/20 rounded-full px-2 py-0.5 hover:bg-emerald-900/50 hover:border-emerald-500/40 transition-colors"
+    >
+        <FileText size={10} className="shrink-0" />
+        <span className="max-w-[140px] truncate">{source.filename}</span>
+        {source.page != null && (
+            <span className="text-emerald-500/70">· p.{source.page}</span>
+        )}
+    </button>
+);
+
+// ── Markdown-ish message renderer (simple version) ─────────────────────────
+const renderMessageContent = (content) => {
+    if (!content) return null;
+    const lines = content.split('\n');
+    return lines.map((line, i) => {
+        if (line.startsWith('### ')) return <h3 key={i} className="text-base font-semibold mt-3 mb-1 text-slate-100">{line.slice(4)}</h3>;
+        if (line.startsWith('## '))  return <h2 key={i} className="text-lg font-bold mt-3 mb-1 text-slate-100">{line.slice(3)}</h2>;
+        if (line.startsWith('# '))   return <h1 key={i} className="text-xl font-bold mt-3 mb-1 text-slate-100">{line.slice(2)}</h1>;
+        if (line.startsWith('- ') || line.startsWith('* '))
+            return <li key={i} className="ml-4 list-disc text-slate-300">{line.slice(2)}</li>;
+        if (line.trim() === '') return <br key={i} />;
+        // inline bold
+        const parts = line.split(/(\*\*.*?\*\*)/g);
+        return (
+            <p key={i} className="text-slate-300 leading-relaxed">
+                {parts.map((part, j) =>
+                    part.startsWith('**') && part.endsWith('**')
+                        ? <strong key={j} className="text-slate-100 font-semibold">{part.slice(2, -2)}</strong>
+                        : part
+                )}
+            </p>
+        );
+    });
+};
+
+// ── Main component ──────────────────────────────────────────────────────────
+const RagInterface = () => {
+    const navigate = useNavigate();
+    const { session_id: urlSessionId } = useParams();
+
+    // Sessions
+    const [sessions, setSessions] = useState([]);
+    const [activeSessionId, setActiveSessionId] = useState(null);
+    const [searchQuery, setSearchQuery] = useState('');
+    const [hoveredSession, setHoveredSession] = useState(null);
+    const [sessionTitleOverflow, setSessionTitleOverflow] = useState(0);
+
+    // Layout
+    const [isSessionListOpen, setIsSessionListOpen] = useState(true);
+    const [isKBPanelOpen, setIsKBPanelOpen] = useState(true);
+    const [isMobile, setIsMobile] = useState(window.innerWidth < 768);
+    const [mobileView, setMobileView] = useState('list');
+
+    // Chat
+    const [inputValue, setInputValue] = useState('');
+    const [isStreaming, setIsStreaming] = useState(false);
+    const abortControllerRef = useRef(null);
+    const messagesEndRef = useRef(null);
+    const textareaRef = useRef(null);
+
+    // Knowledge Base
+    const [files, setFiles] = useState([]);
+    const [isDragOver, setIsDragOver] = useState(false);
+    const fileInputRef = useRef(null);
+
+    // Source Viewer
+    const [selectedSource, setSelectedSource] = useState(null);
+
+    // Modals
+    const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+    const [newSessionTitle, setNewSessionTitle] = useState('');
+    const [newSessionDesc, setNewSessionDesc] = useState('');
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [sessionToDelete, setSessionToDelete] = useState(null);
+    const [isCreating, setIsCreating] = useState(false);
+
+    // Copy
+    const [copiedMessageId, setCopiedMessageId] = useState(null);
+
+    // ── Derived ──────────────────────────────────────────────────────────────
+    const showSessionList = isMobile ? mobileView === 'list' : isSessionListOpen;
+    const showChatArea = !isMobile || mobileView === 'chat';
+    const activeSession = sessions.find(s => s.id === activeSessionId) || null;
+    const messages = activeSession?.messages || [];
+    const filteredSessions = sessions.filter(s =>
+        s.title.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+
+    // ── Effects ──────────────────────────────────────────────────────────────
+    useEffect(() => {
+        fetchSessions();
+    }, []);
+
+    useEffect(() => {
+        if (sessions.length === 0) return;
+        if (urlSessionId) {
+            const match = sessions.find(s => s.id === urlSessionId);
+            if (match) {
+                setActiveSessionId(urlSessionId);
+            } else {
+                navigate(`/rag/${sessions[0].id}`, { replace: true });
+            }
+        } else if (!activeSessionId) {
+            setActiveSessionId(sessions[0].id);
+            navigate(`/rag/${sessions[0].id}`, { replace: true });
+        }
+    }, [sessions, urlSessionId]);
+
+    useEffect(() => {
+        if (activeSessionId) {
+            fetchFiles(activeSessionId);
+        }
+    }, [activeSessionId]);
+
+    useEffect(() => {
+        messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    }, [messages]);
+
+    useEffect(() => {
+        const handleResize = () => {
+            const mobile = window.innerWidth < 768;
+            setIsMobile(mobile);
+            if (mobile && isSessionListOpen) setIsSessionListOpen(false);
+        };
+        window.addEventListener('resize', handleResize);
+        return () => window.removeEventListener('resize', handleResize);
+    }, [isSessionListOpen]);
+
+    // ── API helpers ───────────────────────────────────────────────────────────
+    const fetchSessions = async () => {
+        try {
+            const res = await fetch('/rag_session', { headers: { accept: 'application/json' } });
+            if (!res.ok) throw new Error();
+            const data = await res.json();
+            const list = Array.isArray(data) ? data : (data.sessions || []);
+            setSessions(list.map(s => ({ ...s, messages: s.messages || [] })));
+        } catch {
+            setSessions([]);
+        }
+    };
+
+    const fetchFiles = async (sessionId) => {
+        try {
+            const res = await fetch(`/rag_session/${sessionId}/files`, { headers: { accept: 'application/json' } });
+            if (!res.ok) throw new Error();
+            const data = await res.json();
+            setFiles(Array.isArray(data) ? data : (data.files || []));
+        } catch {
+            setFiles([]);
+        }
+    };
+
+    const handleCreateSession = async () => {
+        if (!newSessionTitle.trim() || isCreating) return;
+        setIsCreating(true);
+        try {
+            const res = await fetch('/rag_session', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ title: newSessionTitle.trim(), description: newSessionDesc.trim() }),
+            });
+            if (!res.ok) throw new Error();
+            const created = await res.json();
+            const newSession = { ...created, messages: [] };
+            setSessions(prev => [newSession, ...prev]);
+            setActiveSessionId(newSession.id);
+            navigate(`/rag/${newSession.id}`);
+            setIsCreateModalOpen(false);
+            setNewSessionTitle('');
+            setNewSessionDesc('');
+            if (isMobile) setMobileView('chat');
+        } catch (err) {
+            console.error('Failed to create session:', err);
+        } finally {
+            setIsCreating(false);
+        }
+    };
+
+    const handleDeleteSession = async () => {
+        if (!sessionToDelete) return;
+        try {
+            await fetch(`/rag_session/${sessionToDelete}`, { method: 'DELETE' });
+        } catch { /* ignore */ }
+        const remaining = sessions.filter(s => s.id !== sessionToDelete);
+        setSessions(remaining);
+        if (activeSessionId === sessionToDelete) {
+            const next = remaining[0];
+            setActiveSessionId(next?.id || null);
+            if (next) navigate(`/rag/${next.id}`);
+            else navigate('/rag');
+        }
+        setIsDeleteModalOpen(false);
+        setSessionToDelete(null);
+    };
+
+    const handleSelectSession = (sessionId) => {
+        setActiveSessionId(sessionId);
+        navigate(`/rag/${sessionId}`);
+        if (isMobile) setMobileView('chat');
+    };
+
+    // ── Chat / SSE ────────────────────────────────────────────────────────────
+    const handleSend = async () => {
+        const text = inputValue.trim();
+        if (!text || isStreaming || !activeSessionId) return;
+
+        const userMsg = {
+            id: `u-${Date.now()}`,
+            role: 'user',
+            content: text,
+            timestamp: new Date().toISOString(),
+        };
+        const botMsgId = `b-${Date.now()}`;
+        const botMsg = {
+            id: botMsgId,
+            role: 'assistant',
+            content: '',
+            sources: [],
+            timestamp: new Date().toISOString(),
+            isStreaming: true,
+        };
+
+        setSessions(prev => prev.map(s =>
+            s.id === activeSessionId
+                ? { ...s, messages: [...s.messages, userMsg, botMsg] }
+                : s
+        ));
+        setInputValue('');
+        setIsStreaming(true);
+
+        const controller = new AbortController();
+        abortControllerRef.current = controller;
+
+        try {
+            const res = await fetch(`/rag_session/${activeSessionId}/chat`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ message: text }),
+                signal: controller.signal,
+            });
+            if (!res.ok) throw new Error('Request failed');
+
+            const reader = res.body.getReader();
+            const decoder = new TextDecoder();
+            let buffer = '';
+            let botText = '';
+            let sourcesAccumulated = [];
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                buffer += decoder.decode(value, { stream: true });
+                const lines = buffer.split('\n');
+                buffer = lines.pop();
+
+                for (const line of lines) {
+                    const raw = line.startsWith('data: ') ? line.slice(6) : line;
+                    if (!raw.trim() || raw === '[DONE]') continue;
+                    try {
+                        const json = JSON.parse(raw);
+                        if (json.content) botText += json.content;
+                        if (json.sources) sourcesAccumulated = json.sources;
+                        setSessions(prev => prev.map(s =>
+                            s.id === activeSessionId
+                                ? {
+                                    ...s, messages: s.messages.map(m =>
+                                        m.id === botMsgId
+                                            ? { ...m, content: botText, sources: sourcesAccumulated }
+                                            : m
+                                    )
+                                }
+                                : s
+                        ));
+                    } catch { /* non-JSON line */ }
+                }
+            }
+
+            setSessions(prev => prev.map(s =>
+                s.id === activeSessionId
+                    ? {
+                        ...s, messages: s.messages.map(m =>
+                            m.id === botMsgId
+                                ? { ...m, content: botText, sources: sourcesAccumulated, isStreaming: false }
+                                : m
+                        )
+                    }
+                    : s
+            ));
+        } catch (err) {
+            if (err.name !== 'AbortError') {
+                setSessions(prev => prev.map(s =>
+                    s.id === activeSessionId
+                        ? {
+                            ...s, messages: s.messages.map(m =>
+                                m.id === botMsgId
+                                    ? { ...m, content: 'Something went wrong. Please try again.', isStreaming: false }
+                                    : m
+                            )
+                        }
+                        : s
+                ));
+            }
+        } finally {
+            setIsStreaming(false);
+            abortControllerRef.current = null;
+        }
+    };
+
+    const handleStop = () => {
+        abortControllerRef.current?.abort();
+        setSessions(prev => prev.map(s =>
+            s.id === activeSessionId
+                ? { ...s, messages: s.messages.map(m => m.isStreaming ? { ...m, isStreaming: false } : m) }
+                : s
+        ));
+        setIsStreaming(false);
+    };
+
+    const handleKeyDown = (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            handleSend();
+        }
+    };
+
+    // ── File upload ───────────────────────────────────────────────────────────
+    const handleFileUpload = useCallback(async (file) => {
+        if (!activeSessionId) return;
+        const allowed = ['.pdf', '.txt', '.docx', '.md'];
+        if (!allowed.some(ext => file.name.toLowerCase().endsWith(ext))) return;
+
+        const tempId = `f-${Date.now()}-${Math.random()}`;
+        setFiles(prev => [...prev, { id: tempId, name: file.name, size: file.size, status: 'uploading', progress: 0 }]);
+
+        const progressInterval = setInterval(() => {
+            setFiles(prev => prev.map(f =>
+                f.id === tempId && f.progress < 90 ? { ...f, progress: f.progress + 15 } : f
+            ));
+        }, 150);
+
+        try {
+            const formData = new FormData();
+            formData.append('file', file);
+            const res = await fetch(`/rag_session/${activeSessionId}/files`, {
+                method: 'POST',
+                body: formData,
+            });
+            clearInterval(progressInterval);
+            if (!res.ok) throw new Error();
+            const data = await res.json();
+            setFiles(prev => prev.map(f =>
+                f.id === tempId
+                    ? { id: data.id, name: data.name || file.name, size: data.size || file.size, status: 'indexing', progress: 100 }
+                    : f
+            ));
+            // Poll for indexing completion
+            const pollId = data.id;
+            const poll = setInterval(async () => {
+                try {
+                    const statusRes = await fetch(`/rag_session/${activeSessionId}/files/${pollId}`);
+                    if (!statusRes.ok) { clearInterval(poll); return; }
+                    const statusData = await statusRes.json();
+                    if (statusData.status === 'ready') {
+                        setFiles(prev => prev.map(f => f.id === pollId ? { ...f, status: 'ready' } : f));
+                        clearInterval(poll);
+                    } else if (statusData.status === 'error') {
+                        setFiles(prev => prev.map(f => f.id === pollId ? { ...f, status: 'error' } : f));
+                        clearInterval(poll);
+                    }
+                } catch { clearInterval(poll); }
+            }, 2000);
+        } catch {
+            clearInterval(progressInterval);
+            setFiles(prev => prev.map(f =>
+                f.id === tempId ? { ...f, status: 'error', progress: 0 } : f
+            ));
+        }
+    }, [activeSessionId]);
+
+    const handleDeleteFile = async (fileId) => {
+        if (!activeSessionId) return;
+        try {
+            await fetch(`/rag_session/${activeSessionId}/files/${fileId}`, { method: 'DELETE' });
+        } catch { /* ignore */ }
+        setFiles(prev => prev.filter(f => f.id !== fileId));
+    };
+
+    const handleCopyMessage = (text, id) => {
+        navigator.clipboard.writeText(text);
+        setCopiedMessageId(id);
+        setTimeout(() => setCopiedMessageId(null), 2000);
+    };
+
+    const formatFileSize = (bytes) => {
+        if (!bytes) return '';
+        if (bytes < 1024) return `${bytes} B`;
+        if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+        return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+    };
+
+    // ── Render ────────────────────────────────────────────────────────────────
+    return (
+        <div className="flex h-full w-full bg-slate-900 text-slate-100 overflow-hidden relative">
+
+            {/* ── Left: Session List ──────────────────────────────────────── */}
+            <AnimatePresence initial={false}>
+                {showSessionList && (
+                    <motion.div
+                        initial={isMobile ? false : { width: 0, opacity: 0 }}
+                        animate={isMobile ? {} : { width: 200, opacity: 1 }}
+                        exit={isMobile ? {} : { width: 0, opacity: 0 }}
+                        transition={{ duration: 0.25, ease: 'easeInOut' }}
+                        className={`${isMobile ? 'w-full pt-16' : ''} bg-slate-900/90 border-r border-slate-700/50 flex flex-col flex-shrink-0 backdrop-blur-xl overflow-hidden`}
+                    >
+                        {/* Header */}
+                        <div className="p-2.5 space-y-2">
+                            <div className="flex items-center justify-between gap-2">
+                                <button
+                                    onClick={() => setIsCreateModalOpen(true)}
+                                    className="flex-1 flex items-center justify-center gap-1.5 bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-500 hover:to-teal-500 text-white py-2 px-3 rounded-lg transition-all shadow-md shadow-emerald-900/30 group"
+                                >
+                                    <Plus size={14} className="group-hover:rotate-90 transition-transform duration-300 shrink-0" />
+                                    <span className="font-medium text-xs whitespace-nowrap">New Session</span>
+                                </button>
+                                {!isMobile && (
+                                    <button
+                                        onClick={() => setIsSessionListOpen(false)}
+                                        className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors shrink-0"
+                                        title="Collapse session list"
+                                    >
+                                        <ChevronLeft size={14} />
+                                    </button>
+                                )}
+                            </div>
+                            <div className="relative">
+                                <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 text-slate-500" size={12} />
+                                <input
+                                    type="text"
+                                    placeholder="Search..."
+                                    value={searchQuery}
+                                    onChange={e => setSearchQuery(e.target.value)}
+                                    className="w-full bg-slate-800/50 border border-slate-700/50 rounded-lg py-1.5 pl-7 pr-2.5 text-xs text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all"
+                                />
+                            </div>
+                        </div>
+
+                        {/* Session list */}
+                        <div className="flex-1 overflow-y-auto px-1.5 space-y-0.5 custom-scrollbar pb-3">
+                            {filteredSessions.length === 0 && (
+                                <div className="flex flex-col items-center justify-center py-10 text-slate-600 gap-2">
+                                    <Database size={24} className="opacity-40" />
+                                    <p className="text-[11px] text-center">No sessions yet.</p>
+                                </div>
+                            )}
+                            {filteredSessions.map(session => (
+                                <div
+                                    key={session.id}
+                                    onClick={() => handleSelectSession(session.id)}
+                                    onMouseEnter={e => {
+                                        const span = e.currentTarget.querySelector('[data-title-span]');
+                                        if (span) setSessionTitleOverflow(Math.max(0, span.scrollWidth - span.offsetWidth));
+                                        setHoveredSession(session.id);
+                                    }}
+                                    onMouseLeave={() => { setHoveredSession(null); setSessionTitleOverflow(0); }}
+                                    className={`group flex items-center justify-between px-2 py-1.5 rounded-lg cursor-pointer transition-all border ${activeSessionId === session.id
+                                        ? 'bg-emerald-900/30 border-emerald-700/50 text-white'
+                                        : 'border-transparent text-slate-400 hover:bg-slate-800/50 hover:text-slate-200'
+                                        }`}
+                                >
+                                    <div className="flex items-center gap-2 overflow-hidden flex-1">
+                                        <div className={`w-5 h-5 rounded-md flex items-center justify-center shrink-0 ${activeSessionId === session.id ? 'bg-emerald-500/20' : 'bg-slate-800'}`}>
+                                            <Database size={11} className={activeSessionId === session.id ? 'text-emerald-400' : 'text-slate-600'} />
+                                        </div>
+                                        <span
+                                            data-title-span
+                                            className="text-xs font-medium whitespace-nowrap"
+                                            style={hoveredSession === session.id && sessionTitleOverflow > 0 ? {
+                                                display: 'inline-block',
+                                                animation: `marquee-session ${Math.max(1.5, sessionTitleOverflow / 40)}s ease-in-out infinite alternate`,
+                                                '--marquee-dist': `-${sessionTitleOverflow}px`,
+                                            } : {
+                                                overflow: 'hidden',
+                                                textOverflow: 'ellipsis',
+                                                display: 'block',
+                                            }}
+                                        >{session.title}</span>
+                                    </div>
+                                    <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
+                                        <button
+                                            onClick={e => { e.stopPropagation(); setSessionToDelete(session.id); setIsDeleteModalOpen(true); }}
+                                            className="p-1 rounded hover:bg-red-500/10 hover:text-red-400 transition-colors"
+                                            title="Delete"
+                                        ><Trash2 size={11} /></button>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            {/* ── Center: Chat Area ───────────────────────────────────────── */}
+            {showChatArea && (
+                <div className="flex-1 flex flex-col min-w-0 h-full">
+                    {/* Chat Header */}
+                    <div className="h-12 border-b border-slate-700/50 bg-slate-900/80 backdrop-blur-sm flex items-center px-3 gap-2 shrink-0">
+                        {/* Session list reopen */}
+                        {!isMobile && !isSessionListOpen && (
+                            <button
+                                onClick={() => setIsSessionListOpen(true)}
+                                className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors shrink-0"
+                                title="Open session list"
+                            >
+                                <ChevronRight size={15} />
+                            </button>
+                        )}
+                        {isMobile && (
+                            <button onClick={() => setMobileView('list')} className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors">
+                                <ChevronLeft size={15} />
+                            </button>
+                        )}
+
+                        {/* Title */}
+                        <div className="flex items-center gap-2 flex-1 min-w-0">
+                            <div className="w-6 h-6 rounded-md bg-emerald-500/20 flex items-center justify-center shrink-0">
+                                <Database size={13} className="text-emerald-400" />
+                            </div>
+                            <span className="text-sm font-semibold truncate text-slate-200">
+                                {activeSession?.title || 'RAG Session'}
+                            </span>
+                        </div>
+
+                        {/* KB panel reopen */}
+                        {!isMobile && !isKBPanelOpen && (
+                            <button
+                                onClick={() => setIsKBPanelOpen(true)}
+                                className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors shrink-0"
+                                title="Open knowledge base"
+                            >
+                                <ChevronLeft size={15} />
+                            </button>
+                        )}
+                    </div>
+
+                    {/* Messages */}
+                    <div className="flex-1 overflow-y-auto custom-scrollbar px-4 py-4 space-y-4">
+                        {!activeSession ? (
+                            // Empty state — no session selected
+                            <div className="h-full flex flex-col items-center justify-center gap-4 text-slate-600">
+                                <div className="w-16 h-16 rounded-2xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center">
+                                    <Database size={28} className="text-emerald-500/60" />
+                                </div>
+                                <div className="text-center">
+                                    <p className="text-slate-400 font-medium mb-1">No session selected</p>
+                                    <p className="text-sm text-slate-600">Create a new session to get started</p>
+                                </div>
+                                <button
+                                    onClick={() => setIsCreateModalOpen(true)}
+                                    className="flex items-center gap-2 bg-emerald-600 hover:bg-emerald-500 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors"
+                                >
+                                    <Plus size={15} />
+                                    New RAG Session
+                                </button>
+                            </div>
+                        ) : messages.length === 0 ? (
+                            // Session exists but no messages yet
+                            <div className="h-full flex flex-col items-center justify-center gap-3 text-slate-600">
+                                <div className="w-14 h-14 rounded-xl bg-emerald-500/10 border border-emerald-500/20 flex items-center justify-center">
+                                    <Zap size={22} className="text-emerald-500/60" />
+                                </div>
+                                <div className="text-center">
+                                    <p className="text-slate-400 font-medium mb-1">Ask about your documents</p>
+                                    <p className="text-sm text-slate-600">Upload files to the knowledge base, then start asking questions</p>
+                                </div>
+                            </div>
+                        ) : (
+                            messages.map(msg => (
+                                <div
+                                    key={msg.id}
+                                    className={`flex gap-3 ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+                                >
+                                    {msg.role === 'assistant' && (
+                                        <div className="w-7 h-7 rounded-full bg-emerald-500/20 border border-emerald-500/30 flex items-center justify-center shrink-0 mt-1">
+                                            <Bot size={13} className="text-emerald-400" />
+                                        </div>
+                                    )}
+                                    <div className={`max-w-[75%] ${msg.role === 'user' ? 'items-end' : 'items-start'} flex flex-col gap-1`}>
+                                        <div className={`relative group rounded-2xl px-4 py-3 shadow-md text-sm ${msg.role === 'user'
+                                            ? 'bg-gradient-to-br from-emerald-600 to-teal-600 text-white rounded-tr-none'
+                                            : 'bg-slate-800/80 border border-slate-700/50 rounded-tl-none'
+                                            }`}>
+                                            {msg.isStreaming && msg.content === '' ? (
+                                                <div className="flex gap-1 py-1">
+                                                    {[0, 1, 2].map(i => (
+                                                        <motion.div key={i} className="w-1.5 h-1.5 bg-emerald-400 rounded-full"
+                                                            animate={{ y: [0, -4, 0] }}
+                                                            transition={{ duration: 0.6, repeat: Infinity, delay: i * 0.15 }} />
+                                                    ))}
+                                                </div>
+                                            ) : (
+                                                <div className="prose prose-invert prose-sm max-w-none">
+                                                    {renderMessageContent(msg.content)}
+                                                </div>
+                                            )}
+                                            {/* Copy button */}
+                                            {!msg.isStreaming && (
+                                                <button
+                                                    onClick={() => handleCopyMessage(msg.content, msg.id)}
+                                                    className="absolute top-2 right-2 p-1 rounded opacity-0 group-hover:opacity-100 transition-opacity text-slate-500 hover:text-slate-300 hover:bg-slate-700/50"
+                                                >
+                                                    {copiedMessageId === msg.id
+                                                        ? <CheckCheck size={11} className="text-emerald-400" />
+                                                        : <Copy size={11} />}
+                                                </button>
+                                            )}
+                                        </div>
+                                        {/* Sources */}
+                                        {msg.role === 'assistant' && msg.sources?.length > 0 && (
+                                            <div className="flex flex-wrap gap-1.5 max-w-full pl-1">
+                                                <span className="text-[10px] text-slate-500 uppercase tracking-wider w-full">Sources</span>
+                                                {msg.sources.map((src, i) => (
+                                                    <SourcePill key={i} source={src} onClick={setSelectedSource} />
+                                                ))}
+                                            </div>
+                                        )}
+                                        <span className="text-[10px] text-slate-600 px-1">
+                                            {new Date(msg.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+                                        </span>
+                                    </div>
+                                </div>
+                            ))
+                        )}
+                        <div ref={messagesEndRef} />
+                    </div>
+
+                    {/* Input Bar */}
+                    <div className="border-t border-slate-700/50 bg-slate-900/80 backdrop-blur-sm px-4 py-3">
+                        <div className="flex items-end gap-2">
+                            <textarea
+                                ref={textareaRef}
+                                value={inputValue}
+                                onChange={e => setInputValue(e.target.value)}
+                                onKeyDown={handleKeyDown}
+                                placeholder={activeSession ? 'Ask about your documents...' : 'Select a session to start'}
+                                disabled={!activeSession || isStreaming}
+                                rows={1}
+                                className="flex-1 bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 resize-none transition-all disabled:opacity-40 custom-scrollbar"
+                                style={{ maxHeight: '120px', overflowY: 'auto' }}
+                            />
+                            {isStreaming ? (
+                                <button
+                                    onClick={handleStop}
+                                    className="p-2.5 rounded-xl bg-slate-700 hover:bg-slate-600 text-slate-300 transition-colors shrink-0"
+                                    title="Stop"
+                                >
+                                    <Square size={16} />
+                                </button>
+                            ) : (
+                                <button
+                                    onClick={handleSend}
+                                    disabled={!inputValue.trim() || !activeSession}
+                                    className="p-2.5 rounded-xl bg-emerald-600 hover:bg-emerald-500 disabled:opacity-40 disabled:cursor-not-allowed text-white transition-colors shrink-0"
+                                    title="Send (Enter)"
+                                >
+                                    <Send size={16} />
+                                </button>
+                            )}
+                        </div>
+                        <p className="text-[10px] text-slate-600 mt-1.5 pl-1">Enter to send · Shift+Enter for new line</p>
+                    </div>
+                </div>
+            )}
+
+            {/* ── Right: Knowledge Base Panel ─────────────────────────────── */}
+            <AnimatePresence>
+                {isKBPanelOpen && !isMobile && (
+                    <motion.div
+                        initial={{ width: 0, opacity: 0 }}
+                        animate={{ width: 260, opacity: 1 }}
+                        exit={{ width: 0, opacity: 0 }}
+                        transition={{ duration: 0.25, ease: 'easeInOut' }}
+                        className="bg-slate-900/90 border-l border-slate-700/50 flex flex-col flex-shrink-0 backdrop-blur-xl overflow-hidden"
+                    >
+                        {/* KB Header */}
+                        <div className="h-12 border-b border-slate-700/50 flex items-center justify-between px-3 shrink-0">
+                            <div className="flex items-center gap-2">
+                                <Upload size={13} className="text-emerald-400" />
+                                <span className="text-xs font-semibold text-slate-300">Knowledge Base</span>
+                            </div>
+                            <button
+                                onClick={() => setIsKBPanelOpen(false)}
+                                className="p-1 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
+                                title="Collapse"
+                            >
+                                <ChevronRight size={14} />
+                            </button>
+                        </div>
+
+                        {/* Upload Zone */}
+                        <div
+                            onDragOver={e => { e.preventDefault(); setIsDragOver(true); }}
+                            onDragLeave={() => setIsDragOver(false)}
+                            onDrop={e => {
+                                e.preventDefault();
+                                setIsDragOver(false);
+                                if (!activeSession) return;
+                                Array.from(e.dataTransfer.files).forEach(handleFileUpload);
+                            }}
+                            onClick={() => activeSession && fileInputRef.current?.click()}
+                            className={classNames(
+                                'mx-3 my-3 border-2 border-dashed rounded-xl p-4 text-center transition-all',
+                                activeSession ? 'cursor-pointer' : 'opacity-40 cursor-not-allowed',
+                                isDragOver && activeSession
+                                    ? 'border-emerald-500/60 bg-emerald-900/20'
+                                    : 'border-slate-700/50 hover:border-emerald-600/40 hover:bg-slate-800/30'
+                            )}
+                        >
+                            <Upload size={18} className="mx-auto text-slate-500 mb-1.5" />
+                            <p className="text-[11px] text-slate-500">
+                                Drop files or <span className="text-emerald-400">browse</span>
+                            </p>
+                            <p className="text-[10px] text-slate-600 mt-0.5">PDF · TXT · DOCX · MD</p>
+                        </div>
+                        <input
+                            ref={fileInputRef}
+                            type="file"
+                            multiple
+                            accept=".pdf,.txt,.docx,.md"
+                            className="hidden"
+                            onChange={e => Array.from(e.target.files).forEach(handleFileUpload)}
+                        />
+
+                        {/* File List */}
+                        <div className="flex-1 overflow-y-auto custom-scrollbar px-2 space-y-1 pb-2">
+                            {files.length === 0 && (
+                                <div className="flex flex-col items-center justify-center py-8 text-slate-600 gap-2">
+                                    <FileText size={20} className="opacity-40" />
+                                    <p className="text-[11px] text-center">No files uploaded yet</p>
+                                </div>
+                            )}
+                            {files.map(file => (
+                                <div key={file.id} className="group px-2.5 py-2 rounded-lg bg-slate-800/40 border border-slate-700/30 hover:border-slate-600/50 transition-colors">
+                                    <div className="flex items-start justify-between gap-2">
+                                        <div className="flex items-start gap-2 min-w-0 flex-1">
+                                            <FileText size={13} className={classNames('shrink-0 mt-0.5', {
+                                                'text-emerald-400': file.status === 'ready',
+                                                'text-slate-500': file.status === 'uploading' || file.status === 'indexing',
+                                                'text-red-400': file.status === 'error',
+                                            })} />
+                                            <div className="min-w-0 flex-1">
+                                                <p className="text-[11px] font-medium text-slate-300 truncate">{file.name}</p>
+                                                <p className="text-[10px] text-slate-600">{formatFileSize(file.size)}</p>
+                                            </div>
+                                        </div>
+                                        <div className="flex items-center gap-1 shrink-0">
+                                            {/* Status icon */}
+                                            {file.status === 'ready' && <Check size={12} className="text-emerald-400" />}
+                                            {file.status === 'indexing' && <RefreshCw size={12} className="text-emerald-400 animate-spin" />}
+                                            {file.status === 'error' && <AlertCircle size={12} className="text-red-400" />}
+                                            {/* Delete */}
+                                            <button
+                                                onClick={() => handleDeleteFile(file.id)}
+                                                className="p-0.5 rounded opacity-0 group-hover:opacity-100 transition-opacity hover:bg-red-500/10 hover:text-red-400 text-slate-500"
+                                                title="Delete file"
+                                            >
+                                                <Trash2 size={11} />
+                                            </button>
+                                        </div>
+                                    </div>
+                                    {/* Upload progress bar */}
+                                    {file.status === 'uploading' && (
+                                        <div className="mt-2 h-1 bg-slate-700 rounded-full overflow-hidden">
+                                            <div
+                                                className="h-full bg-emerald-500 rounded-full transition-all duration-150"
+                                                style={{ width: `${file.progress}%` }}
+                                            />
+                                        </div>
+                                    )}
+                                    {file.status === 'indexing' && (
+                                        <p className="text-[10px] text-emerald-500/70 mt-1">Indexing...</p>
+                                    )}
+                                    {file.status === 'error' && (
+                                        <p className="text-[10px] text-red-400/70 mt-1">Upload failed</p>
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+
+                        {/* KB Footer */}
+                        <div className="px-3 py-2 border-t border-slate-700/50 text-[10px] text-slate-500">
+                            {files.length} file{files.length !== 1 ? 's' : ''} · {files.filter(f => f.status === 'ready').length} ready
+                        </div>
+                    </motion.div>
+                )}
+            </AnimatePresence>
+
+            {/* ── Source Viewer Overlay ───────────────────────────────────── */}
+            {createPortal(
+                <AnimatePresence>
+                    {selectedSource && (
+                        <>
+                            <motion.div
+                                initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                                onClick={() => setSelectedSource(null)}
+                                className="fixed inset-0 bg-black/50 z-[300]"
+                            />
+                            <motion.div
+                                initial={{ x: '100%' }} animate={{ x: 0 }} exit={{ x: '100%' }}
+                                transition={{ type: 'spring', stiffness: 300, damping: 30 }}
+                                className="fixed right-0 top-0 h-full w-full max-w-md bg-slate-900 border-l border-slate-700/50 z-[301] flex flex-col shadow-2xl"
+                            >
+                                <div className="h-14 border-b border-slate-700/50 flex items-center justify-between px-4 shrink-0">
+                                    <div className="flex items-center gap-2 min-w-0">
+                                        <FileText size={15} className="text-emerald-400 shrink-0" />
+                                        <span className="text-sm font-semibold text-slate-200 truncate">{selectedSource.filename}</span>
+                                        {selectedSource.page != null && (
+                                            <span className="text-xs text-slate-500 shrink-0">· p.{selectedSource.page}</span>
+                                        )}
+                                    </div>
+                                    <button
+                                        onClick={() => setSelectedSource(null)}
+                                        className="p-1.5 rounded-lg text-slate-500 hover:text-slate-200 hover:bg-slate-800 transition-colors shrink-0 ml-2"
+                                    >
+                                        <X size={15} />
+                                    </button>
+                                </div>
+                                <div className="flex-1 overflow-y-auto p-5 custom-scrollbar">
+                                    <div className="text-[11px] text-slate-500 uppercase tracking-wider mb-3 flex items-center gap-1.5">
+                                        <Info size={11} />
+                                        Source Chunk
+                                    </div>
+                                    <p className="text-sm text-slate-300 leading-relaxed whitespace-pre-wrap">
+                                        {selectedSource.chunk_text}
+                                    </p>
+                                </div>
+                            </motion.div>
+                        </>
+                    )}
+                </AnimatePresence>,
+                document.body
+            )}
+
+            {/* ── Create Session Modal ────────────────────────────────────── */}
+            {createPortal(
+                <AnimatePresence>
+                    {isCreateModalOpen && (
+                        <>
+                            <motion.div
+                                initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                                onClick={() => setIsCreateModalOpen(false)}
+                                className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200]"
+                            />
+                            <motion.div
+                                initial={{ opacity: 0, scale: 0.95, y: 10 }}
+                                animate={{ opacity: 1, scale: 1, y: 0 }}
+                                exit={{ opacity: 0, scale: 0.95, y: 10 }}
+                                transition={{ duration: 0.15 }}
+                                className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md bg-slate-900 border border-slate-700/60 rounded-2xl shadow-2xl z-[201] p-6"
+                            >
+                                <h2 className="text-base font-bold text-slate-100 mb-4 flex items-center gap-2">
+                                    <div className="w-7 h-7 rounded-lg bg-emerald-500/20 flex items-center justify-center">
+                                        <Database size={14} className="text-emerald-400" />
+                                    </div>
+                                    New RAG Session
+                                </h2>
+                                <div className="space-y-3">
+                                    <div>
+                                        <label className="text-xs text-slate-400 font-medium mb-1.5 block">Session Name *</label>
+                                        <input
+                                            type="text"
+                                            value={newSessionTitle}
+                                            onChange={e => setNewSessionTitle(e.target.value)}
+                                            onKeyDown={e => e.key === 'Enter' && handleCreateSession()}
+                                            placeholder="e.g. Product Documentation Q&A"
+                                            autoFocus
+                                            className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-3 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all"
+                                        />
+                                    </div>
+                                    <div>
+                                        <label className="text-xs text-slate-400 font-medium mb-1.5 block">Description</label>
+                                        <textarea
+                                            value={newSessionDesc}
+                                            onChange={e => setNewSessionDesc(e.target.value)}
+                                            placeholder="What documents will you upload? (optional)"
+                                            rows={2}
+                                            className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-3 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all resize-none"
+                                        />
+                                    </div>
+                                </div>
+                                <div className="flex justify-end gap-2 mt-5">
+                                    <button
+                                        onClick={() => setIsCreateModalOpen(false)}
+                                        className="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 rounded-xl hover:bg-slate-800 transition-colors"
+                                    >Cancel</button>
+                                    <button
+                                        onClick={handleCreateSession}
+                                        disabled={!newSessionTitle.trim() || isCreating}
+                                        className="px-4 py-2 text-sm font-medium bg-emerald-600 hover:bg-emerald-500 disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-xl transition-colors flex items-center gap-2"
+                                    >
+                                        {isCreating && <RefreshCw size={13} className="animate-spin" />}
+                                        Create
+                                    </button>
+                                </div>
+                            </motion.div>
+                        </>
+                    )}
+                </AnimatePresence>,
+                document.body
+            )}
+
+            {/* ── Delete Session Modal ────────────────────────────────────── */}
+            {createPortal(
+                <AnimatePresence>
+                    {isDeleteModalOpen && (
+                        <>
+                            <motion.div
+                                initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                                onClick={() => setIsDeleteModalOpen(false)}
+                                className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200]"
+                            />
+                            <motion.div
+                                initial={{ opacity: 0, scale: 0.95, y: 10 }}
+                                animate={{ opacity: 1, scale: 1, y: 0 }}
+                                exit={{ opacity: 0, scale: 0.95, y: 10 }}
+                                transition={{ duration: 0.15 }}
+                                className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-sm bg-slate-900 border border-slate-700/60 rounded-2xl shadow-2xl z-[201] p-6"
+                            >
+                                <h2 className="text-base font-bold text-slate-100 mb-2">Delete Session?</h2>
+                                <p className="text-sm text-slate-400 mb-5">
+                                    This will permanently delete the session, all messages, and all uploaded files.
+                                </p>
+                                <div className="flex justify-end gap-2">
+                                    <button
+                                        onClick={() => setIsDeleteModalOpen(false)}
+                                        className="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 rounded-xl hover:bg-slate-800 transition-colors"
+                                    >Cancel</button>
+                                    <button
+                                        onClick={handleDeleteSession}
+                                        className="px-4 py-2 text-sm font-medium bg-red-600 hover:bg-red-500 text-white rounded-xl transition-colors"
+                                    >Delete</button>
+                                </div>
+                            </motion.div>
+                        </>
+                    )}
+                </AnimatePresence>,
+                document.body
+            )}
+        </div>
+    );
+};
+
+export default RagInterface;

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -264,7 +264,7 @@ const RagInterface = () => {
         if (isMobile) setMobileView('chat');
     };
 
-    // ── Chat / SSE ────────────────────────────────────────────────────────────
+    // ── Chat ─────────────────────────────────────────────────────────────────
     const handleSend = async () => {
         const text = inputValue.trim();
         if (!text || isStreaming || !activeSessionId) return;
@@ -297,55 +297,29 @@ const RagInterface = () => {
         abortControllerRef.current = controller;
 
         try {
-            const res = await fetch(`/rag_session/${activeSessionId}/chat`, {
+            const docId = files.find(f => f.status === 'ready')?.id;
+            const res = await fetch('/documents/query', {
                 method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ message: text }),
+                headers: { 'Content-Type': 'application/json', accept: 'application/json' },
+                body: JSON.stringify({
+                    human_message: text,
+                    doc_id: docId,
+                    chat_session_id: activeSessionId,
+                }),
                 signal: controller.signal,
             });
             if (!res.ok) throw new Error('Request failed');
 
-            const reader = res.body.getReader();
-            const decoder = new TextDecoder();
-            let buffer = '';
-            let botText = '';
-            let sourcesAccumulated = [];
-
-            while (true) {
-                const { done, value } = await reader.read();
-                if (done) break;
-                buffer += decoder.decode(value, { stream: true });
-                const lines = buffer.split('\n');
-                buffer = lines.pop();
-
-                for (const line of lines) {
-                    const raw = line.startsWith('data: ') ? line.slice(6) : line;
-                    if (!raw.trim() || raw === '[DONE]') continue;
-                    try {
-                        const json = JSON.parse(raw);
-                        if (json.content) botText += json.content;
-                        if (json.sources) sourcesAccumulated = json.sources;
-                        setSessions(prev => prev.map(s =>
-                            s.id === activeSessionId
-                                ? {
-                                    ...s, messages: s.messages.map(m =>
-                                        m.id === botMsgId
-                                            ? { ...m, content: botText, sources: sourcesAccumulated }
-                                            : m
-                                    )
-                                }
-                                : s
-                        ));
-                    } catch { /* non-JSON line */ }
-                }
-            }
+            const data = await res.json();
+            const botText = data.answer || data.response || data.content || JSON.stringify(data);
+            const sources = data.sources || [];
 
             setSessions(prev => prev.map(s =>
                 s.id === activeSessionId
                     ? {
                         ...s, messages: s.messages.map(m =>
                             m.id === botMsgId
-                                ? { ...m, content: botText, sources: sourcesAccumulated, isStreaming: false }
+                                ? { ...m, content: botText, sources, isStreaming: false }
                                 : m
                         )
                     }

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -143,9 +143,10 @@ const RagInterface = () => {
                 const items = Array.isArray(data) ? data : (data.messages || []);
                 const sorted = [...items]
                     .sort((a, b) => (a.message_order || 0) - (b.message_order || 0))
-                    .map(({ created_at, ...item }) => ({
+                    .map(({ created_at, metadata, ...item }) => ({
                         ...item,
                         timestamp: created_at || new Date().toISOString(),
+                        sources: metadata?.sources || [],
                     }));
                 setSessions(prev => prev.map(s =>
                     s.id === activeSessionId ? { ...s, messages: sorted } : s
@@ -396,6 +397,7 @@ const RagInterface = () => {
             const reader = res.body.getReader();
             const decoder = new TextDecoder();
             let accumulated = '';
+            let sources = [];
 
             while (true) {
                 const { done, value } = await reader.read();
@@ -424,6 +426,8 @@ const RagInterface = () => {
                                     }
                                     : s
                             ));
+                        } else if (parsed.sources !== undefined) {
+                            sources = parsed.sources;
                         }
                     } catch { /* skip malformed lines */ }
                 }
@@ -434,7 +438,7 @@ const RagInterface = () => {
                     ? {
                         ...s, messages: s.messages.map(m =>
                             m.id === botMsgId
-                                ? { ...m, isStreaming: false }
+                                ? { ...m, sources, isStreaming: false }
                                 : m
                         )
                     }

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -87,7 +87,9 @@ const RagInterface = () => {
     const [newSessionTitle, setNewSessionTitle] = useState('');
     const [newSessionDesc, setNewSessionDesc] = useState('');
     const [newSessionModel, setNewSessionModel] = useState('');
+    const [newSessionDocs, setNewSessionDocs] = useState([]);
     const [availableModels, setAvailableModels] = useState([]);
+    const [availableDocs, setAvailableDocs] = useState([]);
     const [loadingModels, setLoadingModels] = useState(false);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
     const [sessionToDelete, setSessionToDelete] = useState(null);
@@ -109,6 +111,7 @@ const RagInterface = () => {
     useEffect(() => {
         fetchSessions();
         fetchModels();
+        fetchAvailableDocs();
     }, []);
 
     useEffect(() => {
@@ -185,6 +188,26 @@ const RagInterface = () => {
         }
     };
 
+    const fetchAvailableDocs = async () => {
+        try {
+            const owner = localStorage.getItem('username') || 'regina';
+            const res = await fetch(`/documents?collection=documents&owner=${owner}`, {
+                headers: { accept: 'application/json' },
+            });
+            if (!res.ok) throw new Error();
+            const data = await res.json();
+            const seen = new Set();
+            const unique = (Array.isArray(data) ? data : []).filter(d => {
+                if (seen.has(d.filename)) return false;
+                seen.add(d.filename);
+                return true;
+            });
+            setAvailableDocs(unique.map(d => ({ id: d.doc_id, name: d.filename })));
+        } catch {
+            setAvailableDocs([]);
+        }
+    };
+
     const fetchFiles = async () => {
         try {
             const owner = localStorage.getItem('username') || 'regina';
@@ -221,6 +244,7 @@ const RagInterface = () => {
                     title: newSessionTitle.trim(),
                     description: newSessionDesc.trim(),
                     model: newSessionModel,
+                    metadata: { doc_ids: newSessionDocs },
                 }),
             });
             if (!res.ok) throw new Error();
@@ -233,6 +257,7 @@ const RagInterface = () => {
             setNewSessionTitle('');
             setNewSessionDesc('');
             setNewSessionModel(availableModels[0]?.name || '');
+            setNewSessionDocs([]);
             if (isMobile) setMobileView('chat');
         } catch (err) {
             console.error('Failed to create session:', err);
@@ -297,7 +322,8 @@ const RagInterface = () => {
         abortControllerRef.current = controller;
 
         try {
-            const docId = files.find(f => f.status === 'ready')?.id;
+            const docId = activeSession?.metadata?.doc_ids?.[0]
+                || files.find(f => f.status === 'ready')?.id;
             const res = await fetch('/documents/query', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', accept: 'application/json' },
@@ -926,14 +952,46 @@ const RagInterface = () => {
                                         )}
                                     </div>
                                     <div>
-                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">Description</label>
+                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">Description <span className="text-slate-600">(optional)</span></label>
                                         <textarea
                                             value={newSessionDesc}
                                             onChange={e => setNewSessionDesc(e.target.value)}
-                                            placeholder="What documents will you upload? (optional)"
+                                            placeholder="What will you ask about?"
                                             rows={2}
                                             className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all resize-none"
                                         />
+                                    </div>
+                                    <div>
+                                        <label className="block text-xs font-medium text-slate-400 mb-1.5">Documents</label>
+                                        <div className="bg-slate-800/40 border border-slate-700/30 rounded-xl overflow-y-auto max-h-40 custom-scrollbar p-1">
+                                            {availableDocs.length === 0 ? (
+                                                <div className="p-3 text-center text-[11px] text-slate-500">No documents uploaded yet.</div>
+                                            ) : availableDocs.map(doc => {
+                                                const isSelected = newSessionDocs.includes(doc.id);
+                                                return (
+                                                    <div
+                                                        key={doc.id}
+                                                        onClick={() => setNewSessionDocs(prev =>
+                                                            prev.includes(doc.id)
+                                                                ? prev.filter(id => id !== doc.id)
+                                                                : [...prev, doc.id]
+                                                        )}
+                                                        className={`flex items-center gap-3 p-2 hover:bg-slate-800/60 rounded-lg cursor-pointer transition-colors group select-none ${isSelected ? 'bg-slate-800/30' : ''}`}
+                                                    >
+                                                        <div className={`w-4 h-4 rounded flex items-center justify-center shrink-0 border transition-all ${isSelected ? 'bg-emerald-500 border-emerald-500' : 'border-slate-600 group-hover:border-emerald-400'}`}>
+                                                            {isSelected && <Check size={12} className="text-white" strokeWidth={3} />}
+                                                        </div>
+                                                        <div className="flex items-center gap-2 flex-1 min-w-0">
+                                                            <FileText size={12} className="text-slate-500 shrink-0" />
+                                                            <p className="text-xs font-medium text-slate-300 truncate">{doc.name}</p>
+                                                        </div>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                        <p className="text-[10px] text-slate-500 mt-2 px-1 text-right">
+                                            {newSessionDocs.length} document{newSessionDocs.length !== 1 ? 's' : ''} selected
+                                        </p>
                                     </div>
                                 </div>
                                 <div className="flex justify-end gap-3 px-6 pb-6">

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -5,7 +5,7 @@ import {
     Plus, Search, ChevronLeft, ChevronRight, X, Send, Square,
     Database, FileText, Upload, Trash2, RefreshCw, Check,
     AlertCircle, Copy, CheckCheck, MoreVertical, Zap, Bot,
-    Info
+    Info, Settings
 } from 'lucide-react';
 import classNames from 'classnames';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -76,6 +76,7 @@ const RagInterface = () => {
 
     // Knowledge Base
     const [files, setFiles] = useState([]);
+    const [loadingFiles, setLoadingFiles] = useState(false);
     const [isDragOver, setIsDragOver] = useState(false);
     const fileInputRef = useRef(null);
 
@@ -84,6 +85,8 @@ const RagInterface = () => {
 
     // Modals
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
+    const [modalMode, setModalMode] = useState('create');
+    const [editingSessionId, setEditingSessionId] = useState(null);
     const [newSessionTitle, setNewSessionTitle] = useState('');
     const [newSessionDesc, setNewSessionDesc] = useState('');
     const [newSessionModel, setNewSessionModel] = useState('');
@@ -130,9 +133,28 @@ const RagInterface = () => {
     }, [sessions, urlSessionId]);
 
     useEffect(() => {
-        if (activeSessionId) {
-            fetchFiles();
-        }
+        if (!activeSessionId) return;
+        fetchFiles();
+        const loadHistory = async () => {
+            try {
+                const res = await fetch(`/chat_session/${activeSessionId}/history`);
+                if (!res.ok) throw new Error();
+                const data = await res.json();
+                const items = Array.isArray(data) ? data : (data.messages || []);
+                const sorted = [...items]
+                    .sort((a, b) => (a.message_order || 0) - (b.message_order || 0))
+                    .map(({ created_at, ...item }) => ({
+                        ...item,
+                        timestamp: created_at || new Date().toISOString(),
+                    }));
+                setSessions(prev => prev.map(s =>
+                    s.id === activeSessionId ? { ...s, messages: sorted } : s
+                ));
+            } catch {
+                // keep empty messages on error
+            }
+        };
+        loadHistory();
     }, [activeSessionId]);
 
     useEffect(() => {
@@ -209,6 +231,7 @@ const RagInterface = () => {
     };
 
     const fetchFiles = async () => {
+        setLoadingFiles(true);
         try {
             const owner = localStorage.getItem('username') || 'regina';
             const res = await fetch(`/documents?collection=documents&owner=${owner}`, {
@@ -226,41 +249,75 @@ const RagInterface = () => {
             setFiles(unique.map(d => ({ id: d.doc_id, name: d.filename, status: 'ready' })));
         } catch {
             setFiles([]);
+        } finally {
+            setLoadingFiles(false);
         }
     };
 
-    const handleCreateSession = async () => {
+    const closeSessionModal = () => {
+        setIsCreateModalOpen(false);
+        setModalMode('create');
+        setEditingSessionId(null);
+        setNewSessionTitle('');
+        setNewSessionDesc('');
+        setNewSessionModel(availableModels[0]?.name || '');
+        setNewSessionDocs([]);
+    };
+
+    const handleOpenEditModal = (session) => {
+        setModalMode('edit');
+        setEditingSessionId(session.id);
+        setNewSessionTitle(session.title);
+        setNewSessionDesc(session.description || '');
+        setNewSessionModel(session.model_name || session.model || availableModels[0]?.name || '');
+        setNewSessionDocs(session.metadata?.doc_ids || []);
+        setIsCreateModalOpen(true);
+    };
+
+    const handleSaveSession = async () => {
         if (!newSessionTitle.trim() || isCreating) return;
         setIsCreating(true);
         try {
             const username = localStorage.getItem('username') || 'regina';
-            const res = await fetch('/chat_session/', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    owner: username,
-                    mode: 'rag',
-                    session_type: 'text',
-                    title: newSessionTitle.trim(),
-                    description: newSessionDesc.trim(),
-                    model: newSessionModel,
-                    metadata: { doc_ids: newSessionDocs },
-                }),
-            });
-            if (!res.ok) throw new Error();
-            const created = await res.json();
-            const newSession = { ...created, messages: [] };
-            setSessions(prev => [newSession, ...prev]);
-            setActiveSessionId(newSession.id);
-            navigate(`/rag/${newSession.id}`);
-            setIsCreateModalOpen(false);
-            setNewSessionTitle('');
-            setNewSessionDesc('');
-            setNewSessionModel(availableModels[0]?.name || '');
-            setNewSessionDocs([]);
-            if (isMobile) setMobileView('chat');
+            const payload = {
+                owner: username,
+                mode: 'rag',
+                session_type: 'text',
+                title: newSessionTitle.trim(),
+                description: newSessionDesc.trim(),
+                model_name: newSessionModel,
+                metadata: { doc_ids: newSessionDocs },
+            };
+
+            if (modalMode === 'create') {
+                const res = await fetch('/chat_session/', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                if (!res.ok) throw new Error();
+                const created = await res.json();
+                const newSession = { ...created, messages: [] };
+                setSessions(prev => [newSession, ...prev]);
+                setActiveSessionId(newSession.id);
+                navigate(`/rag/${newSession.id}`);
+                if (isMobile) setMobileView('chat');
+            } else {
+                const res = await fetch(`/chat_session/${editingSessionId}`, {
+                    method: 'PUT',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                if (!res.ok) throw new Error();
+                setSessions(prev => prev.map(s =>
+                    s.id === editingSessionId
+                        ? { ...s, title: payload.title, description: payload.description, model_name: payload.model_name, metadata: payload.metadata }
+                        : s
+                ));
+            }
+            closeSessionModal();
         } catch (err) {
-            console.error('Failed to create session:', err);
+            console.error('Failed to save session:', err);
         } finally {
             setIsCreating(false);
         }
@@ -336,16 +393,48 @@ const RagInterface = () => {
             });
             if (!res.ok) throw new Error('Request failed');
 
-            const data = await res.json();
-            const botText = data.answer || data.response || data.content || JSON.stringify(data);
-            const sources = data.sources || [];
+            const reader = res.body.getReader();
+            const decoder = new TextDecoder();
+            let accumulated = '';
+
+            while (true) {
+                const { done, value } = await reader.read();
+                if (done) break;
+
+                const chunk = decoder.decode(value, { stream: true });
+                const lines = chunk.split('\n');
+
+                for (const line of lines) {
+                    const trimmed = line.trim();
+                    if (!trimmed.startsWith('data:')) continue;
+                    const jsonStr = trimmed.slice(5).trim();
+                    if (!jsonStr) continue;
+                    try {
+                        const parsed = JSON.parse(jsonStr);
+                        if (parsed.data !== undefined) {
+                            accumulated += parsed.data;
+                            setSessions(prev => prev.map(s =>
+                                s.id === activeSessionId
+                                    ? {
+                                        ...s, messages: s.messages.map(m =>
+                                            m.id === botMsgId
+                                                ? { ...m, content: accumulated, isStreaming: true }
+                                                : m
+                                        )
+                                    }
+                                    : s
+                            ));
+                        }
+                    } catch { /* skip malformed lines */ }
+                }
+            }
 
             setSessions(prev => prev.map(s =>
                 s.id === activeSessionId
                     ? {
                         ...s, messages: s.messages.map(m =>
                             m.id === botMsgId
-                                ? { ...m, content: botText, sources, isStreaming: false }
+                                ? { ...m, isStreaming: false }
                                 : m
                         )
                     }
@@ -431,7 +520,16 @@ const RagInterface = () => {
         }
     }, [activeSessionId]);
 
-    const handleDeleteFile = (fileId) => {
+    const handleDeleteFile = async (fileId) => {
+        try {
+            const res = await fetch(`/documents/${fileId}?collection=documents`, {
+                method: 'DELETE',
+                headers: { accept: '*/*' },
+            });
+            if (!res.ok) throw new Error();
+        } catch {
+            // still remove from UI even if API call fails
+        }
         setFiles(prev => prev.filter(f => f.id !== fileId));
     };
 
@@ -537,6 +635,11 @@ const RagInterface = () => {
                                     </div>
                                     <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity shrink-0">
                                         <button
+                                            onClick={e => { e.stopPropagation(); handleOpenEditModal(session); }}
+                                            className="p-1 rounded hover:bg-emerald-500/10 hover:text-emerald-400 transition-colors"
+                                            title="Edit"
+                                        ><Settings size={11} /></button>
+                                        <button
                                             onClick={e => { e.stopPropagation(); setSessionToDelete(session.id); setIsDeleteModalOpen(true); }}
                                             className="p-1 rounded hover:bg-red-500/10 hover:text-red-400 transition-colors"
                                             title="Delete"
@@ -575,9 +678,39 @@ const RagInterface = () => {
                             <div className="w-6 h-6 rounded-md bg-emerald-500/20 flex items-center justify-center shrink-0">
                                 <Database size={13} className="text-emerald-400" />
                             </div>
-                            <span className="text-sm font-semibold truncate text-slate-200">
-                                {activeSession?.title || 'RAG Session'}
-                            </span>
+                            <div className="group relative cursor-default flex flex-col justify-center min-w-0">
+                                <h2 className="text-sm font-semibold text-slate-200 leading-tight truncate">
+                                    {activeSession?.title || 'RAG Session'}
+                                </h2>
+                                <div className="flex items-center gap-1.5">
+                                    <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 animate-pulse shrink-0" />
+                                    <span className="text-[11px] text-slate-400">
+                                        {activeSession?.metadata?.doc_ids?.length || 0} doc{(activeSession?.metadata?.doc_ids?.length || 0) !== 1 ? 's' : ''} referenced
+                                    </span>
+                                </div>
+
+                                {/* Hover Doc IDs Popover */}
+                                <div className="absolute top-10 left-0 mt-1 opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity duration-200 z-[120]">
+                                    <div className="bg-slate-800 border border-slate-700/50 rounded-xl shadow-xl p-3 w-max min-w-[160px] max-w-[260px]">
+                                        <p className="text-[10px] font-semibold text-slate-400 uppercase tracking-wider mb-2">Referenced Documents</p>
+                                        {activeSession?.metadata?.doc_ids?.length > 0 ? (
+                                            <ul className="space-y-1.5">
+                                                {activeSession.metadata.doc_ids.map(id => {
+                                                    const doc = availableDocs.find(d => d.id === id);
+                                                    return (
+                                                        <li key={id} className="flex items-center gap-2 text-xs text-emerald-400">
+                                                            <div className="w-1 h-1 rounded-full bg-emerald-500 shrink-0" />
+                                                            <span className="truncate">{doc ? doc.name : id}</span>
+                                                        </li>
+                                                    );
+                                                })}
+                                            </ul>
+                                        ) : (
+                                            <p className="text-[11px] text-slate-500">No documents configured</p>
+                                        )}
+                                    </div>
+                                </div>
+                            </div>
                         </div>
 
                         {/* KB panel reopen */}
@@ -734,18 +867,30 @@ const RagInterface = () => {
                         className="bg-slate-900/90 border-l border-slate-700/50 flex flex-col flex-shrink-0 backdrop-blur-xl overflow-hidden"
                     >
                         {/* KB Header */}
-                        <div className="h-12 border-b border-slate-700/50 flex items-center justify-between px-3 shrink-0">
+                        <div className="h-16 border-b border-slate-700/50 flex items-center justify-between px-4 shrink-0">
                             <div className="flex items-center gap-2">
-                                <Upload size={13} className="text-emerald-400" />
-                                <span className="text-xs font-semibold text-slate-300">Knowledge Base</span>
+                                <Database size={15} className="text-emerald-400" />
+                                <span className="text-sm font-semibold text-slate-200">Knowledge Base</span>
+                                <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-500/10 text-emerald-400 border border-emerald-500/20 font-mono">
+                                    {files.length}
+                                </span>
                             </div>
-                            <button
-                                onClick={() => setIsKBPanelOpen(false)}
-                                className="p-1 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
-                                title="Collapse"
-                            >
-                                <ChevronRight size={14} />
-                            </button>
+                            <div className="flex items-center gap-1">
+                                <button
+                                    onClick={fetchFiles}
+                                    className="p-1.5 rounded-lg text-slate-500 hover:text-emerald-400 hover:bg-slate-800 transition-colors"
+                                    title="Refresh documents"
+                                >
+                                    <RefreshCw size={13} className={loadingFiles ? 'animate-spin' : ''} />
+                                </button>
+                                <button
+                                    onClick={() => setIsKBPanelOpen(false)}
+                                    className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
+                                    title="Collapse"
+                                >
+                                    <ChevronRight size={14} />
+                                </button>
+                            </div>
                         </div>
 
                         {/* Upload Zone */}
@@ -838,10 +983,6 @@ const RagInterface = () => {
                             ))}
                         </div>
 
-                        {/* KB Footer */}
-                        <div className="px-3 py-2 border-t border-slate-700/50 text-[10px] text-slate-500">
-                            {files.length} file{files.length !== 1 ? 's' : ''} · {files.filter(f => f.status === 'ready').length} ready
-                        </div>
                     </motion.div>
                 )}
             </AnimatePresence>
@@ -899,7 +1040,7 @@ const RagInterface = () => {
                         <motion.div
                             initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
                             className="fixed inset-0 bg-black/60 backdrop-blur-sm z-[200] flex items-center justify-center p-4"
-                            onClick={() => setIsCreateModalOpen(false)}
+                            onClick={closeSessionModal}
                         >
                             <motion.div
                                 initial={{ opacity: 0, scale: 0.95, y: 16 }}
@@ -913,9 +1054,11 @@ const RagInterface = () => {
                                         <div className="w-9 h-9 rounded-xl bg-emerald-500/10 flex items-center justify-center">
                                             <Database size={18} className="text-emerald-400" />
                                         </div>
-                                        <h3 className="text-base font-semibold text-slate-100">New RAG Session</h3>
+                                        <h3 className="text-base font-semibold text-slate-100">
+                                            {modalMode === 'edit' ? 'Edit RAG Session' : 'New RAG Session'}
+                                        </h3>
                                     </div>
-                                    <button onClick={() => setIsCreateModalOpen(false)} className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors">
+                                    <button onClick={closeSessionModal} className="p-1.5 rounded-lg text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors">
                                         <X size={16} />
                                     </button>
                                 </div>
@@ -926,7 +1069,7 @@ const RagInterface = () => {
                                             type="text"
                                             value={newSessionTitle}
                                             onChange={e => setNewSessionTitle(e.target.value)}
-                                            onKeyDown={e => e.key === 'Enter' && handleCreateSession()}
+                                            onKeyDown={e => e.key === 'Enter' && handleSaveSession()}
                                             placeholder="e.g. Product Documentation Q&A"
                                             autoFocus
                                             className="w-full bg-slate-800/60 border border-slate-700/50 rounded-xl px-4 py-2.5 text-sm text-slate-200 placeholder-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/50 transition-all"
@@ -996,16 +1139,16 @@ const RagInterface = () => {
                                 </div>
                                 <div className="flex justify-end gap-3 px-6 pb-6">
                                     <button
-                                        onClick={() => setIsCreateModalOpen(false)}
+                                        onClick={closeSessionModal}
                                         className="px-4 py-2 text-sm text-slate-400 hover:text-slate-200 rounded-xl hover:bg-slate-800 transition-colors"
                                     >Cancel</button>
                                     <button
-                                        onClick={handleCreateSession}
+                                        onClick={handleSaveSession}
                                         disabled={!newSessionTitle.trim() || isCreating}
                                         className="px-4 py-2 text-sm font-medium bg-emerald-600 hover:bg-emerald-500 disabled:opacity-40 disabled:cursor-not-allowed text-white rounded-xl transition-colors flex items-center gap-2"
                                     >
                                         {isCreating && <RefreshCw size={13} className="animate-spin" />}
-                                        Create
+                                        {modalMode === 'edit' ? 'Save' : 'Create'}
                                     </button>
                                 </div>
                             </motion.div>

--- a/src/components/RagInterface.jsx
+++ b/src/components/RagInterface.jsx
@@ -195,7 +195,7 @@ const RagInterface = () => {
             const res = await fetch('/rag_session', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ title: newSessionTitle.trim(), description: newSessionDesc.trim(), model: newSessionModel }),
+                body: JSON.stringify({ title: newSessionTitle.trim(), description: newSessionDesc.trim(), model: newSessionModel, mode: 'rag' }),
             });
             if (!res.ok) throw new Error();
             const created = await res.json();

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import {
@@ -20,6 +20,8 @@ const Sidebar = () => {
     const [isOpen, setIsOpen] = useState(!isMobile); // Default closed on mobile, open on desktop
     const [hoveredItem, setHoveredItem] = useState(null);
     const [tooltipPos, setTooltipPos] = useState({ top: 0, left: 0 });
+    const [openWidth, setOpenWidth] = useState(180);
+    const measureRef = useRef(null);
     const navigate = useNavigate();
     const location = useLocation();
 
@@ -105,11 +107,41 @@ const Sidebar = () => {
 
 
 
-    // Sidebar Width Logic
-    const sidebarWidth = isOpen ? 280 : (isMobile ? 0 : 80);
+    // Measure natural content width from hidden portal element
+    useLayoutEffect(() => {
+        if (measureRef.current) {
+            setOpenWidth(measureRef.current.offsetWidth);
+        }
+    }, [userRole]);
+
+    // Sidebar Width Logic — dynamic based on content
+    const sidebarWidth = isOpen ? openWidth : (isMobile ? 0 : 56);
 
     return (
         <>
+            {/* Hidden measurement element — renders nav at natural width to compute openWidth */}
+            {createPortal(
+                <div
+                    ref={measureRef}
+                    className="fixed opacity-0 pointer-events-none"
+                    style={{ left: '-9999px', top: '-9999px' }}
+                >
+                    <div className="px-2">
+                        {navItems.map(item => (
+                            <div key={item.id} className="flex items-center gap-3 px-2 py-2">
+                                <item.icon size={18} className="shrink-0" />
+                                <span className="text-sm font-medium whitespace-nowrap">{item.label}</span>
+                            </div>
+                        ))}
+                        <div className="flex items-center gap-3 px-2 py-2.5">
+                            <ChevronLeft size={18} className="shrink-0" />
+                            <span className="text-sm font-medium whitespace-nowrap">Collapse Sidebar</span>
+                        </div>
+                    </div>
+                </div>,
+                document.body
+            )}
+
             {/* Mobile Backdrop */}
             <AnimatePresence>
                 {isMobile && isOpen && (
@@ -154,18 +186,18 @@ const Sidebar = () => {
                 )}
             >
                 <div className={classNames(
-                    "h-20 border-b border-slate-700/50 overflow-hidden flex items-center transition-all",
+                    "h-14 border-b border-slate-700/50 overflow-hidden flex items-center transition-all",
                     {
-                        'p-4 justify-between': isOpen || isMobile,
+                        'px-3 justify-between': isOpen || isMobile,
                         'justify-center': !isOpen && !isMobile
                     }
                 )}>
                     <motion.div
-                        className="font-bold text-xl text-white tracking-wide flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
+                        className="font-bold text-base text-white tracking-wide flex items-center gap-2 cursor-pointer hover:opacity-80 transition-opacity"
                         onClick={() => handleNavigation('/')}
                     >
-                        <div className="w-8 h-8 rounded-lg bg-gradient-to-tr from-blue-500 to-purple-600 flex items-center justify-center shrink-0">
-                            <span className="text-lg font-bold">A</span>
+                        <div className="w-7 h-7 rounded-lg bg-gradient-to-tr from-blue-500 to-purple-600 flex items-center justify-center shrink-0">
+                            <span className="text-sm font-bold">A</span>
                         </div>
                         <AnimatePresence>
                             {isOpen && (
@@ -175,7 +207,7 @@ const Sidebar = () => {
                                     exit={{ opacity: 0, width: 0 }}
                                     className="bg-clip-text text-transparent bg-gradient-to-r from-blue-400 to-purple-400 whitespace-nowrap overflow-hidden flex items-center"
                                 >
-                                    Reg<span className="text-cyan-400 font-mono text-2xl font-bold mx-0.5 drop-shadow-[0_0_8px_rgba(34,211,238,0.8)]">I</span>na
+                                    Reg<span className="text-cyan-400 font-mono text-xl font-bold mx-0.5 drop-shadow-[0_0_8px_rgba(34,211,238,0.8)]">I</span>na
                                 </motion.span>
                             )}
                         </AnimatePresence>
@@ -193,7 +225,7 @@ const Sidebar = () => {
                 </div>
 
                 {/* Navigation */}
-                <nav className="flex-1 px-3 py-4 space-y-2 overflow-y-auto overflow-x-hidden">
+                <nav className="flex-1 px-2 py-3 space-y-1 overflow-y-auto overflow-x-hidden">
                     {navItems.map((item) => (
                         <div
                             key={item.id}
@@ -201,7 +233,7 @@ const Sidebar = () => {
                             onMouseEnter={(e) => handleItemHover(e, item.id)}
                             onMouseLeave={() => setHoveredItem(null)}
                             className={classNames(
-                                "flex items-center gap-4 p-3 rounded-xl cursor-pointer transition-all duration-200 group relative",
+                                "flex items-center gap-3 px-2 py-2 rounded-lg cursor-pointer transition-all duration-200 group relative",
                                 {
                                     'bg-slate-700/50 text-blue-400': activeItem === item.id,
                                     'text-slate-400 hover:bg-slate-800/50 hover:text-slate-200': activeItem !== item.id,
@@ -210,7 +242,7 @@ const Sidebar = () => {
                             )}
                         >
                             <item.icon
-                                size={24}
+                                size={18}
                                 className={classNames(
                                     "transition-colors shrink-0",
                                     { 'text-blue-500': activeItem === item.id }
@@ -223,7 +255,7 @@ const Sidebar = () => {
                                         initial={{ opacity: 0, width: 0 }}
                                         animate={{ opacity: 1, width: "auto" }}
                                         exit={{ opacity: 0, width: 0 }}
-                                        className="font-medium whitespace-nowrap overflow-hidden"
+                                        className="text-sm font-medium whitespace-nowrap overflow-hidden"
                                     >
                                         {item.label}
                                     </motion.span>
@@ -263,12 +295,12 @@ const Sidebar = () => {
                         <button
                             onClick={toggleSidebar}
                             className={classNames(
-                                "w-full p-4 flex items-center gap-4 text-slate-400 hover:bg-slate-800/50 hover:text-white transition-colors",
+                                "w-full px-2 py-2.5 flex items-center gap-3 text-slate-400 hover:bg-slate-800/50 hover:text-white transition-colors",
                                 { 'justify-center': !isOpen }
                             )}
                         >
                             <div className={classNames("shrink-0 transition-transform duration-300", { "rotate-180": !isOpen })}>
-                                <ChevronLeft size={24} />
+                                <ChevronLeft size={18} />
                             </div>
                             <AnimatePresence>
                                 {isOpen && (
@@ -276,7 +308,7 @@ const Sidebar = () => {
                                         initial={{ opacity: 0, width: 0 }}
                                         animate={{ opacity: 1, width: "auto" }}
                                         exit={{ opacity: 0, width: 0 }}
-                                        className="font-medium whitespace-nowrap overflow-hidden"
+                                        className="text-sm font-medium whitespace-nowrap overflow-hidden"
                                     >
                                         Collapse Sidebar
                                     </motion.span>
@@ -288,33 +320,32 @@ const Sidebar = () => {
                     {/* User Profile */}
                     <div className={classNames(
                         "transition-all duration-300",
-                        { 'p-4 pt-2': isOpen || isMobile, 'p-2': !isOpen && !isMobile }
+                        { 'px-2 py-2': isOpen || isMobile, 'p-1.5': !isOpen && !isMobile }
                     )}>
                         <button
                             onClick={handleLogout}
                             className={classNames(
-                                "w-full flex items-center gap-3 p-2 rounded-xl hover:bg-red-500/10 hover:border-red-500/20 border border-transparent transition-all cursor-pointer group text-left",
+                                "w-full flex items-center gap-2 p-1.5 rounded-lg hover:bg-red-500/10 hover:border-red-500/20 border border-transparent transition-all cursor-pointer group text-left",
                                 { 'justify-center': !isOpen && !isMobile }
                             )}
                             title="Sign Out"
                         >
-                            <div className="relative">
+                            <div className="relative shrink-0">
                                 <img
                                     src={`https://api.dicebear.com/7.x/avataaars/svg?seed=${username}`}
                                     alt="User"
-                                    className="w-10 h-10 rounded-full bg-slate-600 border-2 border-slate-500 shrink-0 group-hover:border-red-400 transition-colors"
+                                    className="w-8 h-8 rounded-full bg-slate-600 border-2 border-slate-500 group-hover:border-red-400 transition-colors"
                                 />
-                                {/* Status Indicator */}
-                                <div className="absolute bottom-0 right-0 w-3 h-3 bg-green-500 border-2 border-slate-800 rounded-full"></div>
+                                <div className="absolute bottom-0 right-0 w-2 h-2 bg-green-500 border-2 border-slate-800 rounded-full"></div>
                             </div>
 
                             {isOpen && (
                                 <>
                                     <div className="flex flex-col overflow-hidden flex-1">
-                                        <span className="text-sm font-semibold text-slate-200 truncate group-hover:text-red-200 transition-colors">{username}</span>
-                                        <span className="text-xs text-slate-500 truncate group-hover:text-red-300/70 transition-colors">{userRole}</span>
+                                        <span className="text-xs font-semibold text-slate-200 truncate group-hover:text-red-200 transition-colors">{username}</span>
+                                        <span className="text-[11px] text-slate-500 truncate group-hover:text-red-300/70 transition-colors">{userRole}</span>
                                     </div>
-                                    <LogOut size={18} className="text-slate-500 group-hover:text-red-400 transition-colors" />
+                                    <LogOut size={14} className="text-slate-500 group-hover:text-red-400 transition-colors" />
                                 </>
                             )}
                         </button>

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -10,7 +10,8 @@ import {
     User,
     LogOut,
     X,
-    Bot
+    Bot,
+    Database
 } from 'lucide-react';
 import classNames from 'classnames';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -65,6 +66,7 @@ const Sidebar = () => {
         { id: 'home', icon: Home, label: 'Dashboard', path: '/', restricted: true },
         { id: 'chat', icon: MessageSquare, label: 'Chat Session', path: '/chat' },
         { id: 'agent', icon: Bot, label: 'Agent Session', path: '/agent' },
+        { id: 'rag', icon: Database, label: 'RAG Session', path: '/rag' },
         { id: 'profile', icon: User, label: 'Profile', path: '/profile' },
         { id: 'settings', icon: Settings, label: 'Settings', path: '/settings', restricted: true },
     ].filter(item => userRole === 'Admin' || !item.restricted);
@@ -74,6 +76,7 @@ const Sidebar = () => {
         if (currentPath === '/') return 'home';
         if (currentPath.startsWith('/chat')) return 'chat';
         if (currentPath.startsWith('/agent')) return 'agent';
+        if (currentPath.startsWith('/rag')) return 'rag';
         const found = navItems.find(item => item.path !== '/' && currentPath.startsWith(item.path));
         return found ? found.id : '';
     };

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,12 @@
   }
 }
 
+/* Session title marquee scroll */
+@keyframes marquee-session {
+  0%, 15%   { transform: translateX(0); }
+  85%, 100% { transform: translateX(var(--marquee-dist, 0px)); }
+}
+
 /* Custom scrollbar for webkit (Chrome, Safari, Edge) */
 ::-webkit-scrollbar {
   width: 8px;

--- a/vite.config.js
+++ b/vite.config.js
@@ -71,6 +71,10 @@ export default defineConfig({
                 target: 'http://127.0.0.1:8000',
                 changeOrigin: true,
             },
+            '/documents': {
+                target: 'http://127.0.0.1:8000',
+                changeOrigin: true,
+            },
         },
     },
 })


### PR DESCRIPTION
## Summary
- **Create Tool**: Enable the previously disabled "Create Tool" button in the Tool Store panel — opens a modal with fields for Tool Name (required), Description (optional), and Webhook URL (required); calls `POST /agent/tools` with the user's username as `owner` and webhook URL in `metadata`; refreshes the tool list on success
- **Tool Store controls**: Move Collapse and Refresh buttons into the Tool Store panel header (top-right); remove the "Tools" toggle button from the chat session header
- **Reopen affordance**: When the Tool Store is collapsed, a small Wrench icon appears in the chat header to reopen it
- **Header menu cleanup**: Remove "Refresh Tools" item (and its divider) from the chat session header dropdown — refresh is now accessible directly in the Tool Store panel

## Test plan
- [ ] Click "Create Tool" button in the Tool Store panel — modal should open
- [ ] Fill in name and webhook URL, submit — tool should appear in "My Tools" section after refresh
- [ ] Submit with empty required fields — button should stay disabled
- [ ] Click the X icon in the Tool Store header — panel should collapse
- [ ] Verify Wrench icon appears in chat header when panel is collapsed; click it to reopen
- [ ] Click the refresh (↺) icon in the Tool Store header — tools should reload
- [ ] Confirm "Refresh Tools" no longer appears in the chat header dropdown menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)